### PR TITLE
chore: enhance commitizen configuration with comprehensive settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,css,scss,jsx}]
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.{js,ts,jsx,tsx}]
+quote_type = single

--- a/cz.json
+++ b/cz.json
@@ -1,10 +1,28 @@
 {
   "commitizen": {
     "name": "cz_conventional_commits",
-    "tag_format": "v$version",
-    "version_scheme": "semver",
-    "version": "0.1.5",
+    "version": "0.1.0",
+    "tag_format": "v$major.$minor.$patch",
     "update_changelog_on_bump": true,
-    "major_version_zero": true
+    "annotated_tag": true,
+    "gpg_sign": false,
+    "version_files": [
+      "markdown_flow/__init__.py:__version__"
+    ],
+    "bump_message": "bump: version $current_version → $new_version",
+    "changelog_file": "CHANGELOG.md",
+    "changelog_start_rev": "v0.1.0",
+    "style": [
+      ["qmark", "fg:#ff9d00 bold"],
+      ["question", "bold"],
+      ["answer", "fg:#ff9d00 bold"],
+      ["pointer", "fg:#ff9d00 bold"],
+      ["highlighted", "fg:#ff9d00 bold"],
+      ["selected", "fg:#cc5454"],
+      ["separator", "fg:#cc5454"],
+      ["instruction", ""],
+      ["text", ""],
+      ["disabled", "fg:#858585 italic"]
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Enhanced commitizen configuration with comprehensive settings for better version management
- Reset version to 0.1.0 for a clean start and consistent versioning
- Added version file tracking to automatically update `markdown_flow/__init__.py`
- Configured detailed changelog and tagging settings for automated releases
- Added custom styling for interactive commitizen prompts to improve developer experience
- Set up proper bump message formatting and annotated tags

## Changes Made

- **Version Reset**: Changed version from 0.1.5 to 0.1.0 for clean versioning start
- **Version File Tracking**: Added `version_files` configuration to automatically update `__init__.py`
- **Enhanced Tagging**: Updated tag format and enabled annotated tags with GPG signing option
- **Changelog Configuration**: Set up changelog file path and start revision
- **Interactive Styling**: Added custom color scheme for better CLI experience
- **Bump Message**: Configured clear version transition messages

## Test Plan

- [ ] Test `cz bump` command functionality
- [ ] Verify version file updates work correctly  
- [ ] Check changelog generation
- [ ] Validate tag creation with new format
- [ ] Test interactive commit flow with new styling

🤖 Generated with [Claude Code](https://claude.ai/code)