### PR TITLE
fix: correct version to v0.2.1 and fix workflow version calculation logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,16 +69,12 @@ jobs:
           if cz bump --dry-run 2>/dev/null; then
             echo "bump_needed=true" >> $GITHUB_OUTPUT
 
-            # Get the new version that would be created
-            NEW_VERSION=$(cz bump --dry-run | grep "bump: version" | sed 's/.*→ //')
-            echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-
-            # Update only the commitizen version configuration before bumping
-            sed -i.bak "/^\[tool\.commitizen\]/,/^\[/ s/^version = \"[^\"]*\"/version = \"$NEW_VERSION\"/" pyproject.toml
-            rm -f pyproject.toml.bak
-
-            # Now run cz bump which will create a single commit with all changes
+            # Run cz bump which will create a single commit with all version changes
             cz bump --yes
+
+            # Get the new version after bump
+            NEW_VERSION=$(python -c "import markdown_flow; print(markdown_flow.__version__)")
+            echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
 
             # Generate changelog content for release (without creating file)
             CHANGELOG_CONTENT=$(cz changelog --dry-run)

--- a/markdown_flow/__init__.py
+++ b/markdown_flow/__init__.py
@@ -82,4 +82,4 @@ __all__ = [
 ]
 
 # Version information
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ disallow_incomplete_defs = false
 # =============================================================================
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.2.0"
+version = "0.2.1"
 tag_format = "v$major.$minor.$patch"
 update_changelog_on_bump = true
 annotated_tag = true


### PR DESCRIPTION
## Summary
- Fix incorrect version bump from v0.2.0 to v0.3.0 (should be v0.2.1) 
- Fix workflow logic that causes incorrect version calculations
- Reset to correct v0.2.1 after fix commits

## Root Cause Analysis
The workflow had a logic error where it:
1. Pre-calculated and updated pyproject.toml version
2. Then ran `cz bump --yes` which recalculated the version incorrectly
3. This caused PATCH changes to be bumped as MINOR

## Changes Made
- **Reset version to v0.2.1**: Only fix commits since v0.2.0, should be PATCH increment
- **Simplify workflow**: Let commitizen handle all version calculations atomically
- **Remove premature version updates**: Prevent interference with commitizen logic
- **Get version after bump**: More reliable than predicting version

## Verification
- `cz bump --dry-run` from fix commit shows correct PATCH increment (0.2.0 → 0.2.1)
- Workflow now lets commitizen make all version decisions without interference

## Next Steps
- Delete incorrect v0.3.0 tag after merge
- Create v0.2.1 GitHub release 
- Future releases should have correct version calculations

🤖 Generated with [Claude Code](https://claude.ai/code)