### PR TITLE
feat!: switch multiline preserved fences to !===

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,7 @@ if result.stderr: print('Errors:', result.stderr)
 
 - `CONTENT`: Regular markdown content processed by LLM
 - `INTERACTION`: User input blocks with `?[]` syntax requiring validation
-- `PRESERVED_CONTENT`: Output-as-is blocks using inline `===content===` or multiline fences `!===` ... `!===` (3+ `=`)
+- `PRESERVED_CONTENT`: Output-as-is blocks using inline `!===content!===` or multiline fences `!===` ... `!===` (3+ `=`)
 
 **InteractionType** - Interaction format enumeration
 
@@ -1053,7 +1053,7 @@ mf = ValidatedMarkdownFlow(document, llm_provider, validators)
 
 ### Output Format Standards
 
-- Output instructions use `===content===` format internally
+- Output instructions use `!===` multiline fence format internally
 - Gets converted to `[output]` format for external consumption
 - Preserved content blocks maintain exact formatting
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,7 @@ if result.stderr: print('Errors:', result.stderr)
 
 - `CONTENT`: Regular markdown content processed by LLM
 - `INTERACTION`: User input blocks with `?[]` syntax requiring validation
-- `PRESERVED_CONTENT`: Output-as-is blocks wrapped in `===` markers
+- `PRESERVED_CONTENT`: Output-as-is blocks using inline `===content===` or multiline fences `!===` ... `!===` (3+ `=`)
 
 **InteractionType** - Interaction format enumeration
 

--- a/README.md
+++ b/README.md
@@ -241,10 +241,11 @@ Hello {{name}}! Welcome to our platform.
 
 # Preserved content - output as-is
 """
-===
+# Multiline fence with leading '!'
+!===
 This content is preserved exactly as written.
 No LLM processing or variable replacement.
-===
+!===
 """
 ```
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Enumeration of different block types in MarkdownFlow documents.
 class BlockType(Enum):
     CONTENT = "content"                    # Regular markdown content
     INTERACTION = "interaction"            # User interaction blocks (?[...])
-    PRESERVED_CONTENT = "preserved_content" # Content wrapped in === markers
+    PRESERVED_CONTENT = "preserved_content" # Content wrapped in !=== markers (inline or multiline)
 ```
 
 **Block Structure:**

--- a/README_CN.md
+++ b/README_CN.md
@@ -223,7 +223,7 @@ MarkdownFlow 文档中不同块类型的枚举。
 class BlockType(Enum):
     CONTENT = "content"                    # 常规 markdown 内容
     INTERACTION = "interaction"            # 用户交互块 (?[...])
-    PRESERVED_CONTENT = "preserved_content" # 用 !=== 起止行标记的多行内容，或行内 ===content===
+    PRESERVED_CONTENT = "preserved_content" # 用 !=== 标记的内容（单行或多行格式）
 ```
 
 **块结构：**

--- a/README_CN.md
+++ b/README_CN.md
@@ -223,7 +223,7 @@ MarkdownFlow 文档中不同块类型的枚举。
 class BlockType(Enum):
     CONTENT = "content"                    # 常规 markdown 内容
     INTERACTION = "interaction"            # 用户交互块 (?[...])
-    PRESERVED_CONTENT = "preserved_content" # 用 === 标记包装的内容
+    PRESERVED_CONTENT = "preserved_content" # 用 !=== 起止行标记的多行内容，或行内 ===content===
 ```
 
 **块结构：**
@@ -239,12 +239,13 @@ class BlockType(Enum):
 ?[%{{choice}} 选项 A | 选项 B | 输入自定义选项...]
 """
 
-# 保留内容 - 原样输出
+# 保留内容 - 原样输出（多行）
 """
-===
+# 以感叹号开头并至少 3 个等号作为分隔线
+!===
 此内容完全按原样保留。
 没有 LLM 处理或变量替换。
-===
+!===
 """
 ```
 

--- a/markdown_flow/constants.py
+++ b/markdown_flow/constants.py
@@ -21,16 +21,16 @@ INTERACTION_PATTERN_SPLIT = r"((?<!\\)\?\[[^\]]*\](?!\())"  # Pattern for re.spl
 COMPILED_INTERACTION_REGEX = re.compile(INTERACTION_PATTERN)  # Main interaction pattern matcher
 COMPILED_LAYER1_INTERACTION_REGEX = COMPILED_INTERACTION_REGEX  # Layer 1: Basic format validation (alias)
 COMPILED_LAYER2_VARIABLE_REGEX = re.compile(r"^%\{\{([^}]+)\}\}(.*)$")  # Layer 2: Variable detection
-COMPILED_LAYER3_ELLIPSIS_REGEX = re.compile(r"^(.*?)\.\.\.(.*)")  # Layer 3: Split content around ellipsis
-COMPILED_LAYER3_BUTTON_VALUE_REGEX = re.compile(r"^(.+?)//(.+)$")  # Layer 3: Parse Button//value format
+COMPILED_LAYER3_ELLIPSIS_REGEX = re.compile(r"^(.*)\.\.\.(.*)")  # Layer 3: Split content around ellipsis
+COMPILED_LAYER3_BUTTON_VALUE_REGEX = re.compile(r"^(.+)//(.+)$")  # Layer 3: Parse Button//value format
 COMPILED_BRACE_VARIABLE_REGEX = re.compile(
     r"(?<!%)\{\{([^}]+)\}\}"  # Match {{variable}} format for replaceable variables
 )
 COMPILED_INTERACTION_CONTENT_RECONSTRUCT_REGEX = re.compile(
-    r"(\?\[.*?\.\.\.).*?(\])"  # Reconstruct interaction content: prefix + question + suffix
+    r"(\?\[[^]]*\.\.\.)([^]]*\])"  # Reconstruct interaction content: prefix + question + suffix
 )
 COMPILED_BRACKETS_CLEANUP_REGEX = re.compile(r"[\[\]()]")
-COMPILED_VARIABLE_REFERENCE_CLEANUP_REGEX = re.compile(r"%\{\{.*?\}\}")
+COMPILED_VARIABLE_REFERENCE_CLEANUP_REGEX = re.compile(r"%\{\{[^}]*\}\}")
 COMPILED_WHITESPACE_CLEANUP_REGEX = re.compile(r"\s+")
 
 # Document parsing constants (using shared INTERACTION_PATTERN defined above)

--- a/markdown_flow/constants.py
+++ b/markdown_flow/constants.py
@@ -37,7 +37,9 @@ COMPILED_WHITESPACE_CLEANUP_REGEX = re.compile(r"\s+")
 
 # Separators
 BLOCK_SEPARATOR = r"\n\s*---\s*\n"
-TRIPLE_EQUALS_DELIMITER = "==="
+# Multiline preserved block fence: starts with '!' followed by 3 or more '='
+PRESERVE_FENCE_PATTERN = r"^!={3,}\s*$"
+COMPILED_PRESERVE_FENCE_REGEX = re.compile(PRESERVE_FENCE_PATTERN)
 
 # Output instruction markers
 OUTPUT_INSTRUCTION_PREFIX = "[输出]"

--- a/markdown_flow/core.py
+++ b/markdown_flow/core.py
@@ -257,7 +257,7 @@ class MarkdownFlow:
         """Process preserved content block, output as-is without LLM call."""
         block = self.get_block(block_index)
 
-        # Extract preserved content (remove === markers)
+        # Extract preserved content (remove !=== markers)
         content = extract_preserved_content(block.content)
 
         # Replace variables

--- a/markdown_flow/enums.py
+++ b/markdown_flow/enums.py
@@ -27,4 +27,4 @@ class BlockType(Enum):
 
     CONTENT = "content"  # Regular document content blocks
     INTERACTION = "interaction"  # Interactive blocks requiring user input
-    PRESERVED_CONTENT = "preserved_content"  # Special blocks: inline ===content=== or multiline !===...!===
+    PRESERVED_CONTENT = "preserved_content"  # Special blocks: inline !===content!=== or multiline !===...!===

--- a/markdown_flow/enums.py
+++ b/markdown_flow/enums.py
@@ -27,4 +27,4 @@ class BlockType(Enum):
 
     CONTENT = "content"  # Regular document content blocks
     INTERACTION = "interaction"  # Interactive blocks requiring user input
-    PRESERVED_CONTENT = "preserved_content"  # Special content blocks marked with === delimiters
+    PRESERVED_CONTENT = "preserved_content"  # Special blocks: inline ===content=== or multiline !===...!===

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ exclude = [
     "dist/",
     ".venv/",
     "venv/",
-    "*.egg-info/",
+    ".*\\.egg-info/",
 ]
 
 # Per-module options


### PR DESCRIPTION
This PR changes the multiline preserved block fences from lines containing only `===` to lines starting with `!==` followed by three or more equals.\n\n- Inline preserved syntax `===inline===` remains supported (unchanged)\n- Multiline preserved blocks now use lines like `!===`, `!====` as start/end markers\n- Updated parsing, extraction, and output-instruction processing\n- Updated docs in AGENTS.md, README.md and README_CN.md\n\nBREAKING CHANGE: Multiline preserved blocks previously fenced with `===` must be migrated to `!===` (3+ `=`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserved-content blocks now support visible !=== markers: inline (!===content!===) and fenced multiline (!=== ... !===).

* **Refactor**
  * Replaced legacy === delimiter with the new !=== fence-style for preserved blocks.

* **Documentation**
  * Guides and examples updated to show the !=== inline and multiline syntax; preserved content remains unprocessed (no variable substitution).

* **Chores**
  * Non-functional build/configuration tweak.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->