### PR TITLE
fix: update preserved content format - change inline format from !===…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,7 @@ if result.stderr: print('Errors:', result.stderr)
 
 - `CONTENT`: Regular markdown content processed by LLM
 - `INTERACTION`: User input blocks with `?[]` syntax requiring validation
-- `PRESERVED_CONTENT`: Output-as-is blocks using inline `!===content!===` or multiline fences `!===` ... `!===` (3+ `=`)
+- `PRESERVED_CONTENT`: Output-as-is blocks using inline `===content===` or multiline fences `!===` ... `!===` (3+ `=`)
 
 **InteractionType** - Interaction format enumeration
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ Enumeration of different block types in MarkdownFlow documents.
 class BlockType(Enum):
     CONTENT = "content"                    # Regular markdown content
     INTERACTION = "interaction"            # User interaction blocks (?[...])
-    PRESERVED_CONTENT = "preserved_content" # Content wrapped in !=== markers (inline or multiline)
+    PRESERVED_CONTENT = "preserved_content" # Content wrapped in === (inline) or !=== (multiline) markers
 ```
 
 **Block Structure:**
@@ -257,6 +257,9 @@ Hello {{name}}! Welcome to our platform.
 
 # Preserved content - output as-is
 """
+# Inline format (single line)
+===Fixed title===
+
 # Multiline fence with leading '!'
 !===
 This content is preserved exactly as written.

--- a/README_CN.md
+++ b/README_CN.md
@@ -239,7 +239,7 @@ MarkdownFlow 文档中不同块类型的枚举。
 class BlockType(Enum):
     CONTENT = "content"                    # 常规 markdown 内容
     INTERACTION = "interaction"            # 用户交互块 (?[...])
-    PRESERVED_CONTENT = "preserved_content" # 用 !=== 标记的内容（单行或多行格式）
+    PRESERVED_CONTENT = "preserved_content" # 用 === (单行) 或 !=== (多行) 标记的内容
 ```
 
 **块结构：**
@@ -255,9 +255,12 @@ class BlockType(Enum):
 ?[%{{choice}} 选项 A | 选项 B | 输入自定义选项...]
 """
 
-# 保留内容 - 原样输出（多行）
+# 保留内容 - 原样输出
 """
-# 以感叹号开头并至少 3 个等号作为分隔线
+# 单行格式
+===固定标题===
+
+# 多行格式 - 以感叹号开头并至少 3 个等号作为分隔线
 !===
 此内容完全按原样保留。
 没有 LLM 处理或变量替换。


### PR DESCRIPTION
…content!=== to ===content===

- Update single-line preserved content format to use ===content=== (exactly 3 equals)
- Keep multiline preserved content format as !===...!=== (3+ equals with ! prefix)
- Update all regex patterns and processing logic in utils.py
- Update documentation in README.md, README_CN.md, and AGENTS.md
- Update test cases in tests/prompt.py to use new format
- Maintain backward compatibility for multiline format
- Add proper detection logic to distinguish between single-line and multiline formats

🤖 Generated with [Claude Code](https://claude.ai/code)