### PR TITLE
feat: add next interaction context prompts

### DIFF
--- a/markdown_flow/__init__.py
+++ b/markdown_flow/__init__.py
@@ -88,4 +88,4 @@ __all__ = [
     "replace_variables_in_text",
 ]
 
-__version__ = "0.2.81"
+__version__ = "0.2.82"

--- a/markdown_flow/constants.py
+++ b/markdown_flow/constants.py
@@ -237,3 +237,16 @@ CONTEXT_CONVERSATION_TEMPLATE = f"{CONTEXT_CONVERSATION_MARKER}\n{{content}}"
 CONTEXT_BUTTON_OPTIONS_TEMPLATE = (
     f"{CONTEXT_BUTTON_OPTIONS_MARKER}\n可选的预定义选项包括：{{button_options}}\n注意：用户如果选择了这些选项，都应该接受；如果输入了自定义内容，只要是对问题的合理回答即可接受。"
 )
+
+# Next interaction context prompt templates
+NEXT_INTERACTION_CONTEXT_INTRO = (
+    "The next interaction will appear immediately after this content. When generating the current content, connect to it naturally. "
+    "You may briefly restate, explain, or set up the available choices so the user understands what they will decide next, but do not output the interaction syntax or answer on the user's behalf."
+)
+NEXT_INTERACTION_TEXT_INPUT_TEMPLATE = "The next interaction asks the user to answer in text: {question}"
+NEXT_INTERACTION_SINGLE_CHOICE_TEMPLATE = "The next interaction is a single-choice question. The user will choose one option from: {options}"
+NEXT_INTERACTION_MULTIPLE_CHOICE_TEMPLATE = "The next interaction is a multiple-choice question. The user can choose one or more options from: {options}"
+NEXT_INTERACTION_SINGLE_CHOICE_WITH_TEXT_INTRO = "The next interaction is a single-choice question with an optional custom text answer."
+NEXT_INTERACTION_MULTIPLE_CHOICE_WITH_TEXT_INTRO = "The next interaction is a multiple-choice question with an optional custom text answer."
+NEXT_INTERACTION_PREDEFINED_OPTIONS_TEMPLATE = "The predefined options are: {options}."
+NEXT_INTERACTION_CUSTOM_TEXT_PROMPT_TEMPLATE = "The custom text prompt is: {question}"

--- a/markdown_flow/constants.py
+++ b/markdown_flow/constants.py
@@ -240,6 +240,7 @@ CONTEXT_BUTTON_OPTIONS_TEMPLATE = (
 
 # Next interaction context prompt templates
 NEXT_INTERACTION_CONTEXT_INTRO = (
+    "This next-interaction context is an explicit exception to any general instruction that would otherwise forbid next-step setup, follow-up questions, or choice framing. "
     "The next interaction will appear immediately after this content. When generating the current content, connect to it naturally. "
     "You may briefly restate, explain, or set up the available choices so the user understands what they will decide next, but do not output the interaction syntax or answer on the user's behalf."
 )

--- a/markdown_flow/constants.py
+++ b/markdown_flow/constants.py
@@ -240,7 +240,6 @@ CONTEXT_BUTTON_OPTIONS_TEMPLATE = (
 
 # Next interaction context prompt templates
 NEXT_INTERACTION_CONTEXT_INTRO = (
-    "This next-interaction context is an explicit exception to any general instruction that would otherwise forbid next-step setup, follow-up questions, or choice framing. "
     "The next interaction will appear immediately after this content. When generating the current content, connect to it naturally. "
     "You may briefly restate, explain, or set up the available choices so the user understands what they will decide next, but do not output the interaction syntax or answer on the user's behalf."
 )

--- a/markdown_flow/core.py
+++ b/markdown_flow/core.py
@@ -1263,10 +1263,6 @@ class MarkdownFlow:
         if self._document_prompt:
             system_parts.append(f"# Document Prompt\n\n{self._document_prompt}")
 
-        next_interaction_context = self._build_next_interaction_context_prompt(block_index, variables)
-        if next_interaction_context:
-            system_parts.append(next_interaction_context)
-
         # Combine all parts and add as system message
         if system_parts:
             system_msg = "\n\n".join(system_parts)
@@ -1297,6 +1293,10 @@ class MarkdownFlow:
         # Use XML tags to clarify this is a processing instruction, not content to output
         if self._output_language:
             user_content = f"<output_language_instruction>\n🚨 OUTPUT: 100% {self._output_language} - Translate ALL non-{self._output_language} words/phrases to {self._output_language} 🚨\n</output_language_instruction>\n\n{user_content}"
+
+        next_interaction_context = self._build_next_interaction_context_prompt(block_index, variables)
+        if next_interaction_context:
+            user_content = f"{user_content}\n\n{next_interaction_context}"
 
         # Add processed content as user message (as instruction to LLM)
         messages.append({"role": "user", "content": user_content})

--- a/markdown_flow/core.py
+++ b/markdown_flow/core.py
@@ -1263,6 +1263,10 @@ class MarkdownFlow:
         if self._document_prompt:
             system_parts.append(f"# Document Prompt\n\n{self._document_prompt}")
 
+        next_interaction_context = self._build_next_interaction_context_prompt(block_index, variables)
+        if next_interaction_context:
+            system_parts.append(next_interaction_context)
+
         # Combine all parts and add as system message
         if system_parts:
             system_msg = "\n\n".join(system_parts)
@@ -1293,10 +1297,6 @@ class MarkdownFlow:
         # Use XML tags to clarify this is a processing instruction, not content to output
         if self._output_language:
             user_content = f"<output_language_instruction>\n🚨 OUTPUT: 100% {self._output_language} - Translate ALL non-{self._output_language} words/phrases to {self._output_language} 🚨\n</output_language_instruction>\n\n{user_content}"
-
-        next_interaction_context = self._build_next_interaction_context_prompt(block_index, variables)
-        if next_interaction_context:
-            user_content = f"{user_content}\n\n{next_interaction_context}"
 
         # Add processed content as user message (as instruction to LLM)
         messages.append({"role": "user", "content": user_content})
@@ -1340,12 +1340,13 @@ class MarkdownFlow:
         option_displays: list[str],
     ) -> str:
         """Format the type-specific part of the next interaction prompt."""
-        options = ", ".join(option_displays)
+        options = json.dumps(option_displays, ensure_ascii=False) if option_displays else ""
+        question_text = json.dumps(question, ensure_ascii=False) if question else ""
 
         if interaction_type == InteractionType.TEXT_ONLY:
             if not question:
                 return ""
-            return NEXT_INTERACTION_TEXT_INPUT_TEMPLATE.format(question=question)
+            return NEXT_INTERACTION_TEXT_INPUT_TEMPLATE.format(question=question_text)
 
         if interaction_type in [InteractionType.BUTTONS_ONLY, InteractionType.NON_ASSIGNMENT_BUTTON]:
             if not options:
@@ -1362,7 +1363,7 @@ class MarkdownFlow:
             if options:
                 detail_parts.append(NEXT_INTERACTION_PREDEFINED_OPTIONS_TEMPLATE.format(options=options))
             if question:
-                detail_parts.append(NEXT_INTERACTION_CUSTOM_TEXT_PROMPT_TEMPLATE.format(question=question))
+                detail_parts.append(NEXT_INTERACTION_CUSTOM_TEXT_PROMPT_TEMPLATE.format(question=question_text))
             return " ".join(detail_parts)
 
         if interaction_type == InteractionType.BUTTONS_MULTI_WITH_TEXT:
@@ -1370,7 +1371,7 @@ class MarkdownFlow:
             if options:
                 detail_parts.append(NEXT_INTERACTION_PREDEFINED_OPTIONS_TEMPLATE.format(options=options))
             if question:
-                detail_parts.append(NEXT_INTERACTION_CUSTOM_TEXT_PROMPT_TEMPLATE.format(question=question))
+                detail_parts.append(NEXT_INTERACTION_CUSTOM_TEXT_PROMPT_TEMPLATE.format(question=question_text))
             return " ".join(detail_parts)
 
         return ""

--- a/markdown_flow/core.py
+++ b/markdown_flow/core.py
@@ -25,6 +25,14 @@ from .constants import (
     INTERACTION_PROMPT_BASE,
     INTERACTION_PROMPT_WITH_TRANSLATION,
     LLM_PROVIDER_REQUIRED_ERROR,
+    NEXT_INTERACTION_CONTEXT_INTRO,
+    NEXT_INTERACTION_CUSTOM_TEXT_PROMPT_TEMPLATE,
+    NEXT_INTERACTION_MULTIPLE_CHOICE_TEMPLATE,
+    NEXT_INTERACTION_MULTIPLE_CHOICE_WITH_TEXT_INTRO,
+    NEXT_INTERACTION_PREDEFINED_OPTIONS_TEMPLATE,
+    NEXT_INTERACTION_SINGLE_CHOICE_TEMPLATE,
+    NEXT_INTERACTION_SINGLE_CHOICE_WITH_TEXT_INTRO,
+    NEXT_INTERACTION_TEXT_INPUT_TEMPLATE,
     OUTPUT_LANGUAGE_INSTRUCTION_BOTTOM,
     OUTPUT_LANGUAGE_INSTRUCTION_TOP,
     UNSUPPORTED_PROMPT_TYPE_ERROR,
@@ -1286,10 +1294,86 @@ class MarkdownFlow:
         if self._output_language:
             user_content = f"<output_language_instruction>\n🚨 OUTPUT: 100% {self._output_language} - Translate ALL non-{self._output_language} words/phrases to {self._output_language} 🚨\n</output_language_instruction>\n\n{user_content}"
 
+        next_interaction_context = self._build_next_interaction_context_prompt(block_index, variables)
+        if next_interaction_context:
+            user_content = f"{user_content}\n\n{next_interaction_context}"
+
         # Add processed content as user message (as instruction to LLM)
         messages.append({"role": "user", "content": user_content})
 
         return messages
+
+    def _build_next_interaction_context_prompt(
+        self,
+        block_index: int,
+        variables: dict[str, str | list[str]] | None,
+    ) -> str:
+        """Build natural prompt context from the immediately following interaction block."""
+        blocks = self.get_all_blocks()
+        next_index = block_index + 1
+        if next_index >= len(blocks):
+            return ""
+
+        next_block = blocks[next_index]
+        if next_block.block_type != BlockType.INTERACTION:
+            return ""
+
+        interaction_content = replace_variables_in_text(next_block.content, variables or {})
+        parse_result = InteractionParser().parse(interaction_content)
+        if parse_result.get("error"):
+            return ""
+
+        question = parse_result.get("question", "").strip()
+        buttons = parse_result.get("buttons") or []
+        option_displays = [button.get("display", "").strip() for button in buttons if button.get("display", "").strip()]
+
+        detail = self._format_next_interaction_detail(parse_result.get("type"), question, option_displays)
+        if not detail:
+            return ""
+
+        return f"{NEXT_INTERACTION_CONTEXT_INTRO}\n{detail}"
+
+    def _format_next_interaction_detail(
+        self,
+        interaction_type: InteractionType | None,
+        question: str,
+        option_displays: list[str],
+    ) -> str:
+        """Format the type-specific part of the next interaction prompt."""
+        options = ", ".join(option_displays)
+
+        if interaction_type == InteractionType.TEXT_ONLY:
+            if not question:
+                return ""
+            return NEXT_INTERACTION_TEXT_INPUT_TEMPLATE.format(question=question)
+
+        if interaction_type in [InteractionType.BUTTONS_ONLY, InteractionType.NON_ASSIGNMENT_BUTTON]:
+            if not options:
+                return ""
+            return NEXT_INTERACTION_SINGLE_CHOICE_TEMPLATE.format(options=options)
+
+        if interaction_type == InteractionType.BUTTONS_MULTI_SELECT:
+            if not options:
+                return ""
+            return NEXT_INTERACTION_MULTIPLE_CHOICE_TEMPLATE.format(options=options)
+
+        if interaction_type == InteractionType.BUTTONS_WITH_TEXT:
+            detail_parts = [NEXT_INTERACTION_SINGLE_CHOICE_WITH_TEXT_INTRO]
+            if options:
+                detail_parts.append(NEXT_INTERACTION_PREDEFINED_OPTIONS_TEMPLATE.format(options=options))
+            if question:
+                detail_parts.append(NEXT_INTERACTION_CUSTOM_TEXT_PROMPT_TEMPLATE.format(question=question))
+            return " ".join(detail_parts)
+
+        if interaction_type == InteractionType.BUTTONS_MULTI_WITH_TEXT:
+            detail_parts = [NEXT_INTERACTION_MULTIPLE_CHOICE_WITH_TEXT_INTRO]
+            if options:
+                detail_parts.append(NEXT_INTERACTION_PREDEFINED_OPTIONS_TEMPLATE.format(options=options))
+            if question:
+                detail_parts.append(NEXT_INTERACTION_CUSTOM_TEXT_PROMPT_TEMPLATE.format(question=question))
+            return " ".join(detail_parts)
+
+        return ""
 
     def _extract_translatable_content(self, interaction_content: str) -> tuple[str, dict[str, Any] | None]:
         """Extract translatable parts from interaction content as JSON format


### PR DESCRIPTION
## Summary
- Append natural next-interaction context to content block prompts when the immediately following block is interactive.
- Centralize the new prompt text in markdown_flow/constants.py.
- Treat variable and no-variable option interactions uniformly while using only display labels.

## Validation
- python3.11 -m pytest -v
- pre-commit run --all-files

## Notes
- Local exploratory tests were used for verification but are intentionally not included in git.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for including the next interaction block’s context in generated prompts, improving continuity so follow-up questions appear more naturally.
  * Expanded prompt handling across text input, single-choice, multiple-choice, and variants that include optional custom text answers.
  * Introduced dedicated “next interaction context” templates to format the immediate next step consistently and reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->