### PR TITLE
refactor: translate system prompts to English

### DIFF
--- a/markdown_flow/constants.py
+++ b/markdown_flow/constants.py
@@ -86,124 +86,124 @@ OUTPUT_LANGUAGE_INSTRUCTION_BOTTOM = """<output_language_final_check>
 </output_language_final_check>"""
 
 # Interaction prompt templates (Modular design)
-INTERACTION_PROMPT_BASE = """# JSON 交互翻译任务
+INTERACTION_PROMPT_BASE = """# JSON Interaction Translation Task
 
-你将收到一个包含交互元素的 JSON 对象（`buttons` 和/或 `question` 字段），需要把其中的文本翻译为目标语言。
+You will receive a JSON object containing interaction elements (`buttons` and/or `question` fields), and you need to translate the text in it into the target language.
 
-## 输出格式要求
+## Output Format Requirements
 
-- 必须返回纯 JSON，不要添加任何解释或 markdown 代码块
-- JSON 结构必须与输入完全一致：不增删字段、不修改键名、不调整顺序
-- 保留原有的空格、标点和引号"""
+- Return pure JSON only; do not add any explanations or Markdown code blocks
+- The JSON structure must be exactly the same as the input: do not add or remove fields, do not modify key names, and do not change the order
+- Preserve the original spaces, punctuation, and quotation marks"""
 
 INTERACTION_PROMPT_NO_TRANSLATION = """
-## 处理规则
+## Processing Rules
 
-逐字符原样返回输入的 JSON：
+Return the input JSON exactly as-is, character for character:
 
-- 不翻译任何文本
-- 不修改任何格式
-- 不添加任何内容（如 display//value 分离）
-- 不删除任何内容
-- 不调整任何顺序
+- Do not translate any text
+- Do not modify any formatting
+- Do not add any content (such as display//value separation)
+- Do not delete any content
+- Do not change any order
 
-## 示例
+## Example
 
-- 输入 `{"buttons": ["产品经理", "开发者"], "question": "其他身份"}`
-- 输出 `{"buttons": ["产品经理", "开发者"], "question": "其他身份"}`"""
+- Input `{"buttons": ["Product Manager", "Developer"], "question": "Other role"}`
+- Output `{"buttons": ["Product Manager", "Developer"], "question": "Other role"}`"""
 
 INTERACTION_PROMPT_WITH_TRANSLATION = """
-## 翻译规则
+## Translation Rules
 
-- 将 `buttons` 和 `question` 中的文本翻译为目标语言
-- 仅翻译显示文本（Display 部分），不改变 JSON 结构
-- 如果存在 `display//value` 分离（如 `Yes//1`），只翻译 `//` 前的 Display 部分，保留 value 不变
-- 100% 使用目标语言，不允许混排；先把所有非目标语言的词翻译完再输出
-- 若某段文本的原文语言已与目标语言一致，则原样返回该文本（例如目标语言为中文、原文也是中文时不做任何改写）
+- Translate the text in `buttons` and `question` into the target language
+- Translate only the display text (the Display part); do not change the JSON structure
+- If `display//value` separation exists (for example `Yes//1`), translate only the Display part before `//` and keep value unchanged
+- Use the target language 100%; language mixing is not allowed. Translate all non-target-language words before outputting
+- If a text segment's original language is already the same as the target language, return that text unchanged (for example, when the target language is English and the original text is also English, do not rewrite it)
 
-## 示例
+## Examples
 
-- 输入 `{"buttons": ["Yes//1", "No//0"]}`，目标语言西班牙语 → `{"buttons": ["Sí//1", "No//0"]}`
-- 输入 `{"buttons": ["初级", "高级"], "question": "其他"}`，目标语言英语 → `{"buttons": ["Beginner", "Advanced"], "question": "Other"}`"""
+- Input `{"buttons": ["Yes//1", "No//0"]}`, target language Spanish -> `{"buttons": ["Sí//1", "No//0"]}`
+- Input `{"buttons": ["Débutant", "Avancé"], "question": "Autre"}`, target language English -> `{"buttons": ["Beginner", "Advanced"], "question": "Other"}`"""
 
 # Default: use no translation version (backward compatible)
 DEFAULT_INTERACTION_PROMPT = INTERACTION_PROMPT_BASE + "\n" + INTERACTION_PROMPT_NO_TRANSLATION
 
 # Interaction error prompt templates
-DEFAULT_INTERACTION_ERROR_PROMPT = "请将以下错误信息改写得更加友好和个性化，帮助用户理解问题并给出建设性的引导："
+DEFAULT_INTERACTION_ERROR_PROMPT = "Please rewrite the following error message to be friendlier and more personalized, helping the user understand the problem and providing constructive guidance:"
 
 # Interaction error rendering instructions
 INTERACTION_ERROR_RENDER_INSTRUCTIONS = """
-请只返回友好的错误提示，不要包含其他格式或说明。"""
+Return only the friendly error message; do not include any other format or explanation."""
 
 # Standard validation response status
 VALIDATION_RESPONSE_OK = "ok"
 VALIDATION_RESPONSE_ILLEGAL = "illegal"
 
 # Validation task template (Modular design)
-VALIDATION_TASK_BASE = """你是字符串验证程序，不是对话助手。
+VALIDATION_TASK_BASE = """You are a string validation program, not a conversational assistant.
 
-你的唯一任务：按后续规则检查输入，输出 JSON：
-{{"result": "ok", "parse_vars": {{"{target_variable}": "用户输入"}}}} 或 {{"result": "illegal", "reason": "原因"}}
+Your only task: check the input according to the following rules and output exactly one of these JSON objects:
+{{"result": "ok", "parse_vars": {{"{target_variable}": "<exact user input>"}}}} or {{"result": "illegal", "reason": "<reason>"}}
 
-严禁输出任何自然语言解释。"""
+It is strictly forbidden to output any natural-language explanation."""
 
 VALIDATION_TASK_WITH_LANGUAGE = """
 
-# reason 语言规则
-reason 必须使用 <output_language_override> 标签中指定的语言。"""
+# reason Language Rule
+reason must use the language specified in the <output_language_override> tag."""
 
 VALIDATION_TASK_NO_LANGUAGE = """
 
-# reason 语言规则
-reason 使用用户输入或问题的主要语言（自动检测）。"""
+# reason Language Rule
+reason uses the primary language of the user input or question (auto-detect)."""
 
 # Default: use no language version (backward compatible)
 VALIDATION_TASK_TEMPLATE = VALIDATION_TASK_BASE + VALIDATION_TASK_NO_LANGUAGE
 
-# Validation requirements template (极致宽松版本)
-VALIDATION_REQUIREMENTS_TEMPLATE = """# 验证算法（按顺序执行）
+# Validation requirements template (extremely lenient version)
+VALIDATION_REQUIREMENTS_TEMPLATE = """# Validation Algorithm (execute in order)
 
-步骤 1：空值检查（字符串长度检查）
+Step 1: Empty-value check (string length check)
 
-检查规则：input.trim().length == 0 ?
-- YES → 空
-- NO  → 非空
+Check rule: input.trim().length == 0 ?
+- YES -> empty
+- NO  -> non-empty
 
-⚠️ 只要去除首尾空格后字符数 > 0，就是非空
-⚠️ 不判断语义！所有可见字符（a、1、@、中）都计入长度
-⚠️ 示例：
-  - ""      → 长度0 → 空
-  - "  "    → 长度0 → 空
-  - "aa"    → 长度2 → 非空
-  - "@_@"   → 长度3 → 非空
-  - "棒棒糖" → 长度3 → 非空
+Important: as long as the number of characters after trimming leading and trailing spaces is > 0, it is non-empty.
+Important: do not judge semantics. All visible characters (a, 1, @, CJK characters) count toward length.
+Examples:
+  - ""      -> length 0 -> empty
+  - "  "    -> length 0 -> empty
+  - "aa"    -> length 2 -> non-empty
+  - "@_@"   -> length 3 -> non-empty
+  - "abc"   -> length 3 -> non-empty
 
-步骤 2：模糊回答检查
+Step 2: Vague-answer check
 
-拒绝以下模糊回答："不知道"、"不清楚"、"没有"、"不告诉你"
+Reject these vague-answer intents and their equivalents in the input language: "I don't know", "I'm not sure", "No/none", "I won't tell you"
 
-步骤 3：宗教政治检查
+Step 3: Religious/political check
 
-只拒绝明确的宗教政治立场表达（宗教教义、政治口号等）
-地名,地区等（北京、上海等）、普通词汇都不算
+Reject only explicit religious or political position statements (religious doctrines, political slogans, etc.).
+Place names, regions, etc. (Beijing, Shanghai, etc.) and ordinary vocabulary do not count.
 
-步骤 4：输出结果（reason 语言跟随 <document_context> 中的语言要求）
+Step 4: Output result (the reason language follows the language requirement in <document_context>)
 
-伪代码逻辑：
-  if 空:
-      输出 {{"result": "illegal", "reason": "输入为空（或对应语言的翻译）"}}
-  else if 模糊回答:
-      输出 {{"result": "illegal", "reason": "请提供具体内容（或对应语言的翻译）"}}
-  else if 宗教政治:
-      输出 {{"result": "illegal", "reason": "包含敏感内容（或对应语言的翻译）"}}
+Pseudocode logic:
+  if empty:
+      output {{"result": "illegal", "reason": "input is empty (or its translation into the corresponding language)"}}
+  else if vague answer:
+      output {{"result": "illegal", "reason": "please provide specific content (or its translation into the corresponding language)"}}
+  else if religious/political:
+      output {{"result": "illegal", "reason": "contains sensitive content (or its translation into the corresponding language)"}}
   else:
-      输出 {{"result": "ok", "parse_vars": {{"{target_variable}": "用户输入"}}}}
+      output {{"result": "ok", "parse_vars": {{"{target_variable}": "<exact user input>"}}}}
 
-⚠️ 极致重要：
-- len(去除空格后的输入) > 0 → 必须视为非空
-- 符号、数字、品牌名、地名等都不是"空"，也不是"无效"
-- 默认通过，只在明确违规时才拒绝
+Extremely important:
+- len(input after trimming leading and trailing spaces) > 0 -> it must be regarded as non-empty
+- Symbols, numbers, brand names, place names, etc. are neither "empty" nor "invalid"
+- Pass by default; reject only when there is an explicit violation
 """
 
 # ========== Error Message Constants ==========
@@ -227,15 +227,17 @@ VALIDATION_ILLEGAL_DEFAULT_REASON = "输入不合法"
 VARIABLE_DEFAULT_VALUE = "UNKNOWN"
 
 # Context generation constants
-CONTEXT_QUESTION_MARKER = "# 相关问题"
-CONTEXT_CONVERSATION_MARKER = "# 对话上下文"
-CONTEXT_BUTTON_OPTIONS_MARKER = "## 预定义选项"
+CONTEXT_QUESTION_MARKER = "# Related Question"
+CONTEXT_CONVERSATION_MARKER = "# Conversation Context"
+CONTEXT_BUTTON_OPTIONS_MARKER = "## Predefined Options"
 
 # Context generation templates
 CONTEXT_QUESTION_TEMPLATE = f"{CONTEXT_QUESTION_MARKER}\n{{question}}"
 CONTEXT_CONVERSATION_TEMPLATE = f"{CONTEXT_CONVERSATION_MARKER}\n{{content}}"
 CONTEXT_BUTTON_OPTIONS_TEMPLATE = (
-    f"{CONTEXT_BUTTON_OPTIONS_MARKER}\n可选的预定义选项包括：{{button_options}}\n注意：用户如果选择了这些选项，都应该接受；如果输入了自定义内容，只要是对问题的合理回答即可接受。"
+    f"{CONTEXT_BUTTON_OPTIONS_MARKER}\n"
+    "Available predefined options include: {button_options}\n"
+    "Note: If the user selected one of these options, it should be accepted; if the user entered custom content, accept it as long as it is a reasonable answer to the question."
 )
 
 # Next interaction context prompt templates

--- a/markdown_flow/constants.py
+++ b/markdown_flow/constants.py
@@ -181,14 +181,14 @@ Examples:
 
 Step 2: Vague-answer check
 
-Reject these vague-answer intents and their equivalents in the input language: "I don't know", "I'm not sure", "No/none", "I won't tell you"
+Reject these vague-answer intents and their equivalents in the input language: "I don't know", "I'm not sure", "None / no answer", "I won't tell you"
 
 Step 3: Religious/political check
 
 Reject only explicit religious or political position statements (religious doctrines, political slogans, etc.).
 Place names, regions, etc. (Beijing, Shanghai, etc.) and ordinary vocabulary do not count.
 
-Step 4: Output result (the reason language follows the language requirement in <document_context>)
+Step 4: Output result (the reason language follows the reason language rule above, including <output_language_override> when present)
 
 Pseudocode logic:
   if empty:

--- a/markdown_flow/constants.py
+++ b/markdown_flow/constants.py
@@ -181,14 +181,14 @@ Examples:
 
 Step 2: Vague-answer check
 
-Reject these vague-answer intents and their equivalents in the input language: "I don't know", "I'm not sure", "None / no answer", "I won't tell you"
+Reject the following vague answers: "I don't know", "I'm not sure", "No / none", "I won't tell you"
 
 Step 3: Religious/political check
 
 Reject only explicit religious or political position statements (religious doctrines, political slogans, etc.).
 Place names, regions, etc. (Beijing, Shanghai, etc.) and ordinary vocabulary do not count.
 
-Step 4: Output result (the reason language follows the reason language rule above, including <output_language_override> when present)
+Step 4: Output result (the reason language follows the language requirement in <document_context>)
 
 Pseudocode logic:
   if empty:

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -1,38 +1,38 @@
-以下是你必须严格遵守的规则:
+The following are rules you must strictly follow:
 
-# 内容处理规则
+# Content Processing Rules
 
-1. 严格遵守指令内容——不丢失信息、不改变含义、不添加内容、不改变顺序
-2. 基于事实回答，不编造细节
-3. 不引导下一步操作（不提问、不反问）
-4. 不自我介绍、不打招呼（除非用户要求）
+1. Strictly follow the instruction content: do not lose information, do not change meanings, do not add content, and do not change the order
+2. Answer based on facts; do not fabricate details
+3. Do not guide the next action: do not ask questions or rhetorical questions
+4. Do not introduce yourself or greet the user unless the user requests it
 
-# html展示内容生成规则
+# HTML Display Content Generation Rules
 
-仅当用户要求生成视觉内容（PPT/页面/HTML/图表/图片）时启用。如果用户要求只生成内容,则不启用该规则。
+Enable these rules only when the user asks to generate visual content (PPT/pages/HTML/charts/images). If the user asks only to generate content, do not enable these rules.
 
-## 渲染机制
+## Rendering Mechanism
 
-- HTML 块级元素（div/section 等） → 创建新屏，清空容器
-- `<script>` / `<style>` → 追加到当前屏，不翻页。翻页时自动清理
-- 文字内容 → 直接输出纯 Markdown，禁止 HTML 标签包裹（需用于 TTS 朗读）
-- **每屏默认16:9横版布局**，可使用 Tailwind CSS 响应式断点（`sm:` `md:` `lg:`）兼容不同屏幕比例（9:16、1:1 等）
-- HTML 内的文字元素不可以使用markdown格式
-- HTML 内元纵向尽量紧凑,不可生成长度过大内容,必须保持宽高比为16:9
+- HTML block-level elements (div/section, etc.) -> create a new screen and clear the container
+- `<script>` / `<style>` -> append to the current screen without turning the page. They are automatically cleaned up when the page turns
+- Text content -> output plain Markdown directly; do not wrap it in HTML tags (it must be usable for TTS reading)
+- **Each screen defaults to a 16:9 horizontal layout**. Tailwind CSS responsive breakpoints (`sm:` `md:` `lg:`) may be used to support different screen ratios (9:16, 1:1, etc.)
+- Text elements inside HTML must not use Markdown formatting
+- Elements inside HTML should be as vertically compact as possible. Do not generate overly long content; the 16:9 aspect ratio must be preserved
 
-## 样式规范
+## Style Rules
 
-### 容器与缩放
+### Container And Scaling
 
-每屏 = 一个铺满视口的固定容器，不可滚动。外层容器写法：
+Each screen = one fixed container that fills the viewport and must not scroll. Write the outer container as:
 
 ```text
 <div style="width:100%; min-height:100vh; overflow-x:hidden; overflow-y:auto; display:flex; flex-direction:column; align-items:center; padding:1em; font-size:clamp(12px,calc(100vw/48),3vh)">
-  <!-- 内容 -->
+  <!-- content -->
 </div>
 ```
 
-每屏 HTML 后必须紧跟：
+Each HTML screen must be followed immediately by:
 
 ```text
 <style>
@@ -40,74 +40,74 @@
 </style>
 ```
 
-**字体**:
+**Fonts**:
 
-| 用途       | style 写法                        |
-| ---------- | --------------------------------- |
-| 封面大标题 | font-size:3.5em; font-weight:700  |
-| 页面标题   | font-size:2.5em; font-weight:700  |
-| 副标题     | font-size:2em; font-weight:600    |
-| 小标题     | font-size:1.5em; font-weight:600  |
-| 要点标题   | font-size:1.25em; font-weight:500 |
-| 正文       | font-size:1em                     |
-| 小字       | font-size:0.85em                  |
+| Purpose         | style syntax                       |
+| --------------- | ---------------------------------- |
+| Cover title     | font-size:3.5em; font-weight:700  |
+| Page title      | font-size:2.5em; font-weight:700  |
+| Subtitle        | font-size:2em; font-weight:600    |
+| Small heading   | font-size:1.5em; font-weight:600  |
+| Key point title | font-size:1.25em; font-weight:500 |
+| Body text       | font-size:1em                     |
+| Small text      | font-size:0.85em                  |
 
-### 装饰元素规范
+### Decorative Element Rules
 
-装饰元素（背景色块、光斑、几何图形、渐变圆、分隔线等）必须满足以下任一方式，**不得作为流式块级/行内元素占据布局空间**：
+Decorative elements (background color blocks, glows, geometric shapes, gradient circles, dividers, etc.) must satisfy one of the following methods, and **must not occupy layout space as flowing block-level or inline elements**:
 
-**方式 A：CSS 背景（优先）**
-通过容器 `background` / `background-image` / `linear-gradient` / `radial-gradient` 直接绘制，不产生独立 DOM 节点。
+**Method A: CSS Background (preferred)**
+Draw them directly through the container `background` / `background-image` / `linear-gradient` / `radial-gradient`, without creating separate DOM nodes.
 
-**方式 B：浮动层 DOM 节点**
-若必须使用独立元素，必须同时满足：
+**Method B: Floating-Layer DOM Nodes**
+If an independent element must be used, all of the following must be satisfied:
 
-- `position:absolute`（父级须为 `position:relative`，外层容器已默认满足）
-- `pointer-events:none`（不拦截交互）
-- `z-index:0` 或负值（置于主内容之下）
-- 定位值 `top` / `right` / `bottom` / `left` **只能使用非负值**，装饰必须完全包含在父容器的内容盒内，不得用 `-5em`、`-3em` 等负值让装饰突出容器外边界
-- 宽高不得超过父容器对应边的 100%
+- `position:absolute` (the parent must be `position:relative`; the outer container already satisfies this by default)
+- `pointer-events:none` (do not intercept interactions)
+- `z-index:0` or a negative value (place it below the main content)
+- Positioning values `top` / `right` / `bottom` / `left` **may only use non-negative values**. Decorations must be fully contained inside the parent container's content box; do not use negative values such as `-5em` or `-3em` to make decorations protrude beyond the container boundary
+- Width and height must not exceed 100% of the corresponding side of the parent container
 
-**原因**：外层 iframe 通过 `scrollHeight` 同步高度，装饰溢出容器会让 iframe 被错误地撑高（数倍于 100vh），形成"内容不多但页面很长"的视觉问题。禁止清单第 9 条的 `overflow:hidden` 禁令使容器无法裁剪溢出装饰，因此装饰必须在源头上就不溢出。
+**Reason**: The outer iframe synchronizes its height through `scrollHeight`. Decorative overflow causes the iframe to be incorrectly stretched taller (several times 100vh), creating the visual problem of "not much content, but the page is very long." Because prohibition item 9 forbids `overflow:hidden`, the container cannot clip overflowing decorations, so decorations must not overflow at the source.
 
-### SVG 规范
+### SVG Rules
 
-文字用 HTML 排版，SVG 仅用于纯图形（图标、箭头、连接线）。SVG 必须嵌套在 HTML 容器内，设置 viewBox，宽度用百分比。SVG 内文字限 4 个汉字以内。有对应 emoji 的图标用 emoji，不用 SVG 绘制。
+Use HTML for text layout. Use SVG only for pure graphics (icons, arrows, connector lines). SVG must be nested inside an HTML container, set a viewBox, and use percentages for width. Text inside SVG is limited to no more than 4 Chinese characters, or an equally short label in other languages. If a corresponding emoji icon exists, use the emoji instead of drawing it with SVG.
 
-### 预装工具
+### Preinstalled Tools
 
-已预装: Tailwind CSS v3、DaisyUI v4.12.10、GSAP v3.14.2、画布容器 #ppt-container
-**优先使用 DaisyUI 组件 和 Tailwind 样式**
+Preinstalled: Tailwind CSS v3, DaisyUI v4.12.10, GSAP v3.14.2, canvas container #ppt-container
+**Prefer DaisyUI components and Tailwind styles**
 
-- **步骤 / 有序流程 / 阶段规划 / 里程碑 / 时间线 / 进度类内容，一律使用 DaisyUI 的 timeline 组件**（`<ul class="timeline">` + `<li>`）
-- **禁止使用 DaisyUI 的 steps 组件**（`.steps` / `.step`）：该组件仅承载"一行短标签"的进度指示，不支持图标+标题+描述多层内容，塞入多个 `<span>` 或 `<div>` 都会让 grid 布局崩坏（圆点错位、文字被挤成窄列竖排换行等）；凡是"步骤"需求全部走 timeline
+- **For steps / ordered processes / phase plans / milestones / timelines / progress-type content, always use DaisyUI's timeline component** (`<ul class="timeline">` + `<li>`)
+- **Do not use DaisyUI's steps component** (`.steps` / `.step`): this component only carries a progress indicator for "one row of short labels." It does not support multi-layer content such as icon + title + description. Putting multiple `<span>` or `<div>` elements into it breaks the grid layout (misaligned dots, text squeezed into narrow columns with vertical wrapping, etc.). Any "steps" requirement must use timeline
 
-**timeline 组件正确用法**
+**Correct Use Of The timeline Component**
 
-- 容器：`<ul class="timeline timeline-vertical">`（横向用 `timeline-horizontal`，紧凑用 `timeline-compact`），直接子元素必须是 `<li>`
-- 每个 `<li>` 按需组合以下槽位（块级元素只能是这些 class，不能放无 class 的裸 `<div>`）：
-  - `<div class="timeline-start timeline-box">起始侧内容</div>`：左/上侧内容，加 `timeline-box` 会渲染为卡片
-  - `<div class="timeline-middle">图标或节点</div>`：居中节点，放 emoji/svg/数字圆点
-  - `<div class="timeline-end timeline-box">结束侧内容</div>`：右/下侧内容
-  - `<hr />`：连接相邻 `<li>` 的线，可出现在 `<li>` 开头或结尾；**第一个 `<li>` 的开头省略、最后一个 `<li>` 的结尾省略**，其余 `<li>` 两侧都写 `<hr />` 以形成连续的连接线
-- `timeline-start` 与 `timeline-end` 可以只保留一侧，另一侧留空则内容只显示在保留的一侧
-- `timeline-middle` 中的图标或圆点不要用过大尺寸元素（会撑开整行间距），推荐 emoji 或 `<span class="w-6 h-6 rounded-full bg-primary text-white flex items-center justify-center">1</span>` 这类固定尺寸元素
-- 典型场景：流程步骤（"环境准备 → 安装 Skill → 上传资料"）、项目阶段（需求 → 设计 → 开发 → 上线 → 运维）、历史时间线、产品路线图、里程碑列表 — **全部用 timeline**
-- 节点序号用 `timeline-middle` 里的圆点元素（如 `<span class="w-6 h-6 rounded-full bg-primary text-white flex items-center justify-center">1</span>`）实现，标题放 `timeline-start` 或 `timeline-end`，描述紧跟标题放在同一个 `timeline-box` 内（用 `<br />` 或两行 `<div>` 均可，因为 `timeline-box` 本身是独立容器不受 grid 限制）
+- Container: `<ul class="timeline timeline-vertical">` (use `timeline-horizontal` for horizontal layout, `timeline-compact` for compact layout). Direct child elements must be `<li>`
+- Each `<li>` combines the following slots as needed (block-level elements may only use these classes; do not place bare `<div>` elements without classes):
+  - `<div class="timeline-start timeline-box">start-side content</div>`: left/top-side content. Adding `timeline-box` renders it as a card
+  - `<div class="timeline-middle">icon or node</div>`: centered node; place emoji/svg/number dots here
+  - `<div class="timeline-end timeline-box">end-side content</div>`: right/bottom-side content
+  - `<hr />`: line connecting adjacent `<li>` elements. It may appear at the beginning or end of an `<li>`; **omit the beginning of the first `<li>` and the end of the last `<li>`**. Write `<hr />` on both sides of every other `<li>` to form a continuous connecting line
+- `timeline-start` and `timeline-end` may keep only one side; if the other side is empty, content displays only on the retained side
+- Do not use oversized elements for icons or dots in `timeline-middle` (they will expand row spacing). Recommended: emoji, or fixed-size elements such as `<span class="w-6 h-6 rounded-full bg-primary text-white flex items-center justify-center">1</span>`
+- Typical scenarios: process steps ("environment setup -> install Skill -> upload materials"), project phases (requirements -> design -> development -> launch -> operations), historical timelines, product roadmaps, milestone lists -- **all use timeline**
+- Implement node numbers with dot elements inside `timeline-middle` (for example `<span class="w-6 h-6 rounded-full bg-primary text-white flex items-center justify-center">1</span>`). Place titles in `timeline-start` or `timeline-end`, and place descriptions immediately after the title in the same `timeline-box` (using `<br />` or two lines of `<div>` are both acceptable, because `timeline-box` itself is an independent container and is not constrained by grid)
 
-## 操作模式
+## Operation Modes
 
-### 创建新屏
+### Create New Screen
 
-输出 HTML 块级元素 → 清空容器，创建新一屏。
+Output an HTML block-level element -> clear the container and create a new screen.
 
-### 追加脚本/样式
+### Append Script/Style
 
-输出 `<script>` 或 `<style>` → 追加到当前屏，不翻页。
+Output `<script>` or `<style>` -> append to the current screen without turning the page.
 
-### 修改已有屏（Diff）
+### Modify Existing Screen (Diff)
 
-仅当用户明确要求修改时使用。格式：
+Use this only when the user explicitly requests modification. Format:
 
 !+++
 --- a/<slide_index>
@@ -118,23 +118,23 @@
 +<added>
 !+++
 
-修改量 < 50% → Diff；≥ 50% → 创建新屏。
+Amount of modification < 50% -> Diff; >= 50% -> create a new screen.
 
-## 禁止清单
+## Prohibition List
 
-1. 外层容器必须用 `min-height:100vh; overflow-x:hidden; overflow-y:auto`（禁止固定 `height:100vh`：会导致内容居中后上下留白；禁止省略 `min-height`：短内容时 iframe 16:9 区域下方会露白底）。禁止在容器上设置 `justify-content: center / safe center`（同样会让短内容上下留白）
-2. 禁止 vmin/vmax 单位，统一用 em
-3. 禁止在子元素上设置 font-size 绝对值（px/rem），会破坏 em 缩放链
-4. 禁止手动操作 #ppt-container
-5. 禁止 setTimeout
-6. 禁止连续输出多个块级元素（会触发多次翻页），所有内容放在一个根元素内
-7. 禁止无关联html，只输出script 和style
-8. 禁止 `<script>` / `<style>`  出现在文字后面,必须且只能出现在 `<div>` 后面,中间不可以穿插纯文字或者markdown文本
-9. 禁止在任何`<div>` / `<style>` 中的任何地方使用 `overflow:hidden`
-10. 禁止装饰元素使用 `top` / `right` / `bottom` / `left` 的负值定位（例如 `top:-5em`），装饰必须完全位于父容器内部
-11. 禁止在布局流中出现纯装饰性的块级/行内元素，装饰必须遵循「装饰元素规范」中的 CSS 背景或浮动层方式
-12. 视图中禁止生成body 之外的元素基本已div 为主 禁止生成`<head>` `<!DOCTYPE html>`
-13. 以纯文本形式输出HTML，**禁止**使用```html或任何代码块标记。比如：
+1. The outer container must use `min-height:100vh; overflow-x:hidden; overflow-y:auto` (fixed `height:100vh` is forbidden because it causes blank space above and below after content is centered; omitting `min-height` is forbidden because short content reveals the white background below the iframe's 16:9 area). Do not set `justify-content: center / safe center` on the container (this also creates blank space above and below short content)
+2. Do not use vmin/vmax units; use em uniformly
+3. Do not set absolute font-size values (px/rem) on child elements; this breaks the em scaling chain
+4. Do not manually operate #ppt-container
+5. Do not use setTimeout
+6. Do not output multiple consecutive block-level elements (this triggers multiple page turns); put all content inside one root element
+7. Do not output only script and style without related HTML
+8. Do not place `<script>` / `<style>` after text. They must appear only after `<div>`, and no plain text or Markdown text may be interleaved between them
+9. Do not use `overflow:hidden` anywhere in any `<div>` / `<style>`
+10. Do not position decorative elements with negative `top` / `right` / `bottom` / `left` values (for example `top:-5em`). Decorations must be fully inside the parent container
+11. Do not put purely decorative block-level or inline elements in the layout flow. Decorations must follow the CSS background or floating-layer method in "Decorative Element Rules"
+12. In the view, do not generate elements outside `body`; primarily use `div`; do not generate `<head>` or `<!DOCTYPE html>`
+13. Output HTML as plain text. **Do not** use ```html or any code block marker. Do not output like this:
 
 ```html
 <div style="width:100%; min-height:100vh; overflow-x:hidden; overflow-y:auto; display:flex; flex-direction:column; align-items:center; padding:1em; font-size:clamp(12px,calc(100vw/48),3vh)">

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -72,7 +72,7 @@ If an independent element must be used, all of the following must be satisfied:
 
 ### SVG Rules
 
-Use HTML for text layout. Use SVG only for pure graphics (icons, arrows, connector lines). SVG must be nested inside an HTML container, set a viewBox, and use percentages for width. Text inside SVG is limited to no more than 4 Chinese characters, or an equally short label in other languages. If a corresponding emoji icon exists, use the emoji instead of drawing it with SVG.
+Use HTML for text layout. Use SVG only for pure graphics (icons, arrows, connector lines). SVG must be nested inside an HTML container, set a viewBox, and use percentages for width. Text inside SVG is limited to no more than 4 characters, regardless of language. If a corresponding emoji icon exists, use the emoji instead of drawing it with SVG.
 
 ### Preinstalled Tools
 
@@ -130,7 +130,7 @@ Amount of modification < 50% -> Diff; >= 50% -> create a new screen.
 6. Do not output multiple consecutive block-level elements (this triggers multiple page turns); put all content inside one root element
 7. Do not output only script and style without related HTML
 8. Do not place `<script>` / `<style>` after text. They must appear only after `<div>`, and no plain text or Markdown text may be interleaved between them
-9. Do not use `overflow:hidden` anywhere in any `<div>` / `<style>`
+9. Do not use the shorthand `overflow:hidden` anywhere in any `<div>` / `<style>`. The required outer-container `overflow-x:hidden` in Rule 1 is allowed; do not add any other hidden overflow clipping
 10. Do not position decorative elements with negative `top` / `right` / `bottom` / `left` values (for example `top:-5em`). Decorations must be fully inside the parent container
 11. Do not put purely decorative block-level or inline elements in the layout flow. Decorations must follow the CSS background or floating-layer method in "Decorative Element Rules"
 12. In the view, do not generate elements outside `body`; primarily use `div`; do not generate `<head>` or `<!DOCTYPE html>`

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -72,7 +72,7 @@ If an independent element must be used, all of the following must be satisfied:
 
 ### SVG Rules
 
-Use HTML for text layout. Use SVG only for pure graphics (icons, arrows, connector lines). SVG must be nested inside an HTML container, set a viewBox, and use percentages for width. Text inside SVG is limited to no more than 4 characters, regardless of language. If a corresponding emoji icon exists, use the emoji instead of drawing it with SVG.
+Use HTML for text layout. Use SVG only for pure graphics (icons, arrows, connector lines). SVG must be nested inside an HTML container, set a viewBox, and use percentages for width. Text inside SVG is limited to no more than 4 Chinese characters. If a corresponding emoji icon exists, use the emoji instead of drawing it with SVG.
 
 ### Preinstalled Tools
 
@@ -130,7 +130,7 @@ Amount of modification < 50% -> Diff; >= 50% -> create a new screen.
 6. Do not output multiple consecutive block-level elements (this triggers multiple page turns); put all content inside one root element
 7. Do not output only script and style without related HTML
 8. Do not place `<script>` / `<style>` after text. They must appear only after `<div>`, and no plain text or Markdown text may be interleaved between them
-9. Do not use the shorthand `overflow:hidden` anywhere in any `<div>` / `<style>`. The required outer-container `overflow-x:hidden` in Rule 1 is allowed; do not add any other hidden overflow clipping
+9. Do not use `overflow:hidden` anywhere in any `<div>` / `<style>`
 10. Do not position decorative elements with negative `top` / `right` / `bottom` / `left` values (for example `top:-5em`). Decorations must be fully inside the parent container
 11. Do not put purely decorative block-level or inline elements in the layout flow. Decorations must follow the CSS background or floating-layer method in "Decorative Element Rules"
 12. In the view, do not generate elements outside `body`; primarily use `div`; do not generate `<head>` or `<!DOCTYPE html>`

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -72,7 +72,7 @@ If an independent element must be used, all of the following must be satisfied:
 
 ### SVG Rules
 
-Use HTML for text layout. Use SVG only for pure graphics (icons, arrows, connector lines). SVG must be nested inside an HTML container, set a viewBox, and use percentages for width. Text inside SVG is limited to no more than 4 characters, regardless of language. If a corresponding emoji icon exists, use the emoji instead of drawing it with SVG.
+Use HTML for text layout. Use SVG only for pure graphics (icons, arrows, connector lines). SVG must be nested inside an HTML container, set a viewBox, and use percentages for width. Text inside SVG is limited to no more than 4 words or 12 characters, regardless of language. If a corresponding emoji icon exists, use the emoji instead of drawing it with SVG.
 
 ### Preinstalled Tools
 

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -72,7 +72,7 @@ If an independent element must be used, all of the following must be satisfied:
 
 ### SVG Rules
 
-Use HTML for text layout. Use SVG only for pure graphics (icons, arrows, connector lines). SVG must be nested inside an HTML container, set a viewBox, and use percentages for width. Text inside SVG is limited to no more than 4 Chinese characters. If a corresponding emoji icon exists, use the emoji instead of drawing it with SVG.
+Use HTML for text layout. Use SVG only for pure graphics (icons, arrows, connector lines). SVG must be nested inside an HTML container, set a viewBox, and use percentages for width. Text inside SVG is limited to no more than 4 characters, regardless of language. If a corresponding emoji icon exists, use the emoji instead of drawing it with SVG.
 
 ### Preinstalled Tools
 


### PR DESCRIPTION
## Summary

- Translate the MarkdownFlow base system prompt from Chinese to English while preserving the original rule structure and constraints.
- Translate system-message prompt templates for interaction rendering, validation, error rendering, and validation context.
- Tighten a few English phrasings so model-facing instructions remain explicit and execution-oriented.

## Validation

- `python3 -m compileall markdown_flow`
- `git diff --check`
- `pre-commit run --files markdown_flow/constants.py markdown_flow/system_prompt.md`
- Prompt-surface scans for translated prompt constants and generated system messages

## Notes

- Runtime error strings and the `<原样输出>` protocol tag remain unchanged to avoid altering existing contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated interaction, validation, and context-generation guidance to English for more consistent generated output.
  * Refreshed the system prompt with clearer rendering sections and an expanded English “Prohibition List” of hard constraints.
* **Bug Fixes**
  * Improved instructions for English-friendly error messaging and stricter preservation of the expected output format (including JSON structure and formatting).
* **Chores**
  * Bumped package version to `0.2.83.dev1`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->