### PR TITLE
ci: gate PRs to main on a release __version__

### DIFF
--- a/.github/workflows/check-release-version.yml
+++ b/.github/workflows/check-release-version.yml
@@ -1,0 +1,70 @@
+name: Check release version
+
+# Gate for PRs into main: __version__ in markdown_flow/__init__.py must be a
+# RELEASE version (X.Y.Z), never a pre-release/dev build (e.g. X.Y.Z.devN,
+# X.Y.ZrcN). dev builds are published from feature branches only and must not
+# land on main.
+#
+# To actually block merges, add this check as a required status check in the
+# branch protection / ruleset for `main`.
+#
+# No `paths:` filter on purpose: required checks with path filters get stuck
+# "pending" on PRs that don't touch the filtered files.
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install tooling
+        run: pip install --upgrade packaging
+
+      - name: Ensure __version__ is a release version
+        run: |
+          python - <<'PY'
+          import re
+          import sys
+
+          from packaging.version import InvalidVersion, Version
+
+          path = "markdown_flow/__init__.py"
+          with open(path, encoding="utf-8") as f:
+              text = f.read()
+
+          match = re.search(r"""(?m)^__version__\s*=\s*["'](.+?)["']""", text)
+          if not match:
+              print(f"::error::No __version__ assignment found in {path}.")
+              sys.exit(1)
+
+          raw = match.group(1).strip()
+          try:
+              version = Version(raw)
+          except InvalidVersion:
+              print(f"::error::Invalid __version__ '{raw}' in {path}.")
+              sys.exit(1)
+
+          if version.is_prerelease or version.is_devrelease:
+              print(
+                  f"::error::__version__ = {raw} is a pre-release/dev build and cannot be "
+                  "merged into main. Set a release version (X.Y.Z) first. dev builds "
+                  "(X.Y.Z.devN) are for feature-branch testing only."
+              )
+              sys.exit(1)
+
+          print(f"OK: __version__ = {raw} is a release version.")
+          PY

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1465,10 +1465,9 @@ This rule is **enforced by CI**: the **Check release version** workflow
 `__version__` is a pre-release/dev build. (Add it as a required status check in the `main`
 ruleset to actually block merges.)
 
-> **Why this matters**: `markdown-flow` is consumed by the `ai-shifu` project (pinned in its
-> `src/api/requirements.txt`). A change here is usually made to be used there. ai-shifu also
-> refuses to merge a dev pin into its own `main`, so `markdown-flow`'s `main` must only ever
-> carry release versions — dev builds stay on feature branches for cross-repo testing.
+> **Why this matters**: downstream projects pin `markdown-flow` from its published releases,
+> so `main` must only ever carry release versions. dev builds stay on feature branches for
+> testing and never land on `main`.
 
 #### Triggering from the CLI / by an AI agent
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1460,6 +1460,16 @@ merging) a PR into `main`, the version in `__init__.py` **must be a clean releas
 (`X.Y.Z`), never `X.Y.Z.devN`. If you tested with dev builds, run the Action once more with
 `release_type=release` so the final commit on the branch lands a clean version, then PR that.
 
+This rule is **enforced by CI**: the **Check release version** workflow
+(`.github/workflows/check-release-version.yml`) runs on every PR into `main` and fails if
+`__version__` is a pre-release/dev build. (Add it as a required status check in the `main`
+ruleset to actually block merges.)
+
+> **Why this matters**: `markdown-flow` is consumed by the `ai-shifu` project (pinned in its
+> `src/api/requirements.txt`). A change here is usually made to be used there. ai-shifu also
+> refuses to merge a dev pin into its own `main`, so `markdown-flow`'s `main` must only ever
+> carry release versions — dev builds stay on feature branches for cross-repo testing.
+
 #### Triggering from the CLI / by an AI agent
 
 The Action is fully driveable via `gh`, so an agent can publish and read back the result:


### PR DESCRIPTION
## What

Adds `.github/workflows/check-release-version.yml` — a `pull_request` check (target `main`) that fails when `markdown_flow/__init__.py`'s `__version__` is a pre-release/dev build (e.g. `X.Y.Z.devN`, `X.Y.ZrcN`).

## Why

`markdown-flow` is consumed by `ai-shifu` (pinned in its `requirements.txt`). dev builds are for feature-branch testing only; `main` must always carry a clean release version. ai-shifu already refuses dev pins into its own main — this enforces the same on the source side.

## Behavior

- Runs on every PR into `main` (no `paths:` filter, so it never gets stuck pending as a required check).
- Uses `packaging` to detect pre-release/dev — verified: `0.2.83` passes, `0.2.83.dev1`/`rc1`/`a1` blocked, `.postN` passes.
- `permissions: contents: read` only.

## Follow-up

Add **Check release version** as a required status check in the `main` ruleset to actually block merges.