### PR TITLE
test: [DO NOT MERGE] lefthook CI — unfixable lint error should block

### DIFF
--- a/ci_demo_unfixable.py
+++ b/ci_demo_unfixable.py
@@ -1,0 +1,5 @@
+def handle(value):
+    try:
+        return int(value)
+    except:
+        return 0


### PR DESCRIPTION
**Test PR — do not merge.** Demonstrates the lefthook CI gate on a lint error that **cannot be auto-fixed**.

`ci_demo_unfixable.py` uses a bare `except:` (ruff rule **E722**, not auto-fixable), committed via `--no-verify`:

```python
def handle(value):
    try:
        return int(value)
    except:
        return 0
```

Expectation: `ruff check --fix` cannot fix E722, exits non-zero, so the `lefthook` CI check **fails (red)** and blocks the PR.

(Note on "formatting that can't be fixed": pure formatting is always fixable by `ruff format`. The realistic "unfixable" case is a code-quality/lint rule like this one.)