### PR TITLE
chore: release 0.2.83

### DIFF
--- a/markdown_flow/__init__.py
+++ b/markdown_flow/__init__.py
@@ -88,4 +88,4 @@ __all__ = [
     "replace_variables_in_text",
 ]
 
-__version__ = "0.2.82"
+__version__ = "0.2.83"


### PR DESCRIPTION
## Summary
- Published markdown-flow 0.2.83 to PyPI via the Publish workflow
- Sync __version__ on main to the released version

## Verification
- Publish workflow succeeded: https://github.com/ai-shifu/markdown-flow-agent-py/actions/runs/28421407600
- PyPI contains markdown-flow 0.2.83
- PATH=/private/tmp/mdflow-rebase-tools/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/homebrew/bin:/opt/homebrew/sbin:/Users/sunner/.codex/tmp/arg0/codex-arg0mtCDh9:/Users/sunner/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/sunner/.cargo/bin:/Users/sunner/.antigravity/antigravity/bin:/opt/homebrew/opt/mysql-client/bin:/usr/local/opt/tcl-tk/bin:/opt/homebrew/Caskroom/miniconda/base/bin:/Users/sunner/.nvm/versions/node/v24.3.0/bin:/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/Applications/VMware Fusion.app/Contents/Public:/Users/sunner/.local/bin:/Users/sunner/.local/bin:/Users/sunner/.lmstudio/bin:/Applications/Codex.app/Contents/Resources lefthook run pre-commit --all-files
- python3 -m compileall markdown_flow
- python3 -c "import markdown_flow; print(markdown_flow.__version__)"
- pytest (0 tests collected)