### PR TITLE
feat(scripts): add dev-tools doctor and warn about silent lefthook skips

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This file provides comprehensive guidance to all Coding Agents such as Claude Co
 | Install package (dev) | `pip install -e .` | Root directory |
 | Run code formatting | `ruff format` | Root directory |
 | Run linting | `ruff check --fix` | Root directory |
+| Verify dev toolchain | `python scripts/check_dev_tools.py` | Root directory |
 | Run all checks | `lefthook run pre-commit --all-files` | Root directory |
 | Build package | `python -m build` | Root directory |
 | Run Python tests | `pytest` | Root directory (when tests exist) |
@@ -25,15 +26,23 @@ pip install -e .[dev]  # When dev dependencies are configured
 pip install ruff mypy pytest commitizen  # Python tools; lefthook + markdownlint-cli via brew/npm
 ```
 
+> **The lefthook hooks only run after `lefthook install` wires them into
+> `.git/hooks`, and each hook needs its tool on `PATH`.** If you skip
+> `lefthook install` (or never install lefthook), the pre-commit checks are
+> **silently skipped** on commit — nothing warns you, and the gap only surfaces
+> in CI. Run `python scripts/check_dev_tools.py` to confirm the whole toolchain
+> is installed; it lists anything missing and the exact command to install it.
+
 ## Critical Warnings ⚠️
 
 ### MUST DO Before Any Commit
 
-1. **Run the lefthook checks**: `lefthook run pre-commit --all-files` (MANDATORY)
-2. **Test your changes**: Verify core functionality with test scripts
-3. **Use English for all code**: Comments, variables, docstrings, commit messages
-4. **Follow Conventional Commits**: `type: description` (lowercase type, imperative mood)
-5. **Validate package integrity**: Ensure imports work after installation
+1. **Verify the toolchain is installed**: `python scripts/check_dev_tools.py`. If it reports missing tools, install them with the commands it prints before committing — otherwise the hooks may be silently skipped. Coding agents must run this before `git commit` and pause to surface the install commands rather than committing past missing tools.
+2. **Run the lefthook checks**: `lefthook run pre-commit --all-files` (MANDATORY)
+3. **Test your changes**: Verify core functionality with test scripts
+4. **Use English for all code**: Comments, variables, docstrings, commit messages
+5. **Follow Conventional Commits**: `type: description` (lowercase type, imperative mood)
+6. **Validate package integrity**: Ensure imports work after installation
 
 ### Common Pitfalls to Avoid
 
@@ -1555,6 +1564,7 @@ export PYTHONDONTWRITEBYTECODE=1  # Prevent .pyc files
 | ------- | ---------- | ---------- |
 | `ModuleNotFoundError: No module named 'markdown_flow'` | Import fails | Run `pip install -e .` in project root |
 | Lefthook checks fail | Git commit rejected | Run `lefthook install` then `lefthook run pre-commit --all-files` |
+| Hooks never run, or a tool reports "command not found" | Commits skip checks, or a hook errors | Run `python scripts/check_dev_tools.py` and install what it lists |
 | Import errors during development | Module not found | Ensure editable install: `pip install -e .` |
 | LLM provider errors | Processing fails | Check API keys and network connectivity |
 | Variable replacement not working | Variables not substituted | Verify variable names match exactly (case-sensitive) |

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Doctor for the local lefthook toolchain.
+
+This repository runs its pre-commit / commit-msg checks through lefthook. Those
+git hooks only fire after ``lefthook install`` has wired them into
+``.git/hooks``, and even then each hook shells out to tools that must already be
+on ``PATH`` (ruff, mypy, markdownlint, and commitizen). If lefthook or any of
+those tools is missing the local checks are silently skipped on commit, or fail
+with a cryptic ``command not found`` -- and the gap only surfaces later in CI.
+
+Run this from the repository root before committing to find what is missing and
+exactly how to install it::
+
+    python scripts/check_dev_tools.py
+
+Exit status:
+    0  every required tool is present
+    1  a required tool, or the installed git hook, is missing
+
+NOTE: the pinned versions in the install hints below mirror ``lefthook.yml``'s
+header (the single source of truth). Keep them in sync when a tool is bumped
+there.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Install hints. Versions mirror lefthook.yml's header comment.
+BREW_INSTALL = "brew install lefthook commitizen"
+PIP_INSTALL = "pip install ruff==0.13.1 mypy==1.18.2"
+NPM_INSTALL = "npm install -g markdownlint-cli@0.45.0"
+LEFTHOOK_INSTALL = "lefthook install"
+
+
+class Check:
+    """A single tool/state check and the command that fixes it."""
+
+    def __init__(self, name: str, ok: bool, fix: str):
+        self.name = name
+        self.ok = ok
+        self.fix = fix
+
+
+def _hooks_dir() -> Path | None:
+    """Return the directory git uses for hooks, honoring core.hooksPath."""
+    try:
+        configured = subprocess.run(
+            ["git", "config", "--get", "core.hooksPath"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        if configured.returncode == 0 and configured.stdout.strip():
+            path = Path(configured.stdout.strip())
+            return path if path.is_absolute() else (ROOT / path)
+
+        resolved = subprocess.run(
+            ["git", "rev-parse", "--git-path", "hooks"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    path = Path(resolved.stdout.strip())
+    return path if path.is_absolute() else (ROOT / path)
+
+
+def _lefthook_hook_installed() -> bool:
+    """True when ``lefthook install`` has wired the pre-commit hook in."""
+    hooks_dir = _hooks_dir()
+    if hooks_dir is None:
+        return False
+    pre_commit = hooks_dir / "pre-commit"
+    if not pre_commit.is_file():
+        return False
+    try:
+        return "lefthook" in pre_commit.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+
+
+def collect_checks() -> list[Check]:
+    lefthook_present = shutil.which("lefthook") is not None
+    return [
+        Check("lefthook", lefthook_present, BREW_INSTALL),
+        # Only meaningful once the binary exists; surface the install step
+        # regardless so a half-finished setup is obvious.
+        Check(
+            "lefthook git hooks (lefthook install)",
+            lefthook_present and _lefthook_hook_installed(),
+            LEFTHOOK_INSTALL,
+        ),
+        Check("ruff", shutil.which("ruff") is not None, PIP_INSTALL),
+        Check("mypy", shutil.which("mypy") is not None, PIP_INSTALL),
+        # markdownlint is the markdownlint-cli binary, installed globally via npm.
+        Check("markdownlint", shutil.which("markdownlint") is not None, NPM_INSTALL),
+        Check("cz (commitizen)", shutil.which("cz") is not None, BREW_INSTALL),
+    ]
+
+
+def _fix_lines(missing: list[Check]) -> list[str]:
+    """Unique fix commands, preserving first-seen order."""
+    seen: list[str] = []
+    for check in missing:
+        if check.fix not in seen:
+            seen.append(check.fix)
+    return seen
+
+
+def main() -> int:
+    checks = collect_checks()
+
+    print("lefthook toolchain:")
+    for check in checks:
+        mark = "OK  " if check.ok else "MISS"
+        print(f"  [{mark}] {check.name}")
+    print()
+
+    missing = [c for c in checks if not c.ok]
+    if missing:
+        print("Missing required tooling. Install with:")
+        for line in _fix_lines(missing):
+            print(f"  {line}")
+        print()
+        print("Dev tooling check FAILED. See the commands above.")
+        return 1
+
+    print("All dev tooling present. Local lefthook checks will run.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_dev_tools.py
+++ b/scripts/check_dev_tools.py
@@ -57,7 +57,8 @@ def _hooks_dir() -> Path | None:
             text=True,
         )
         if configured.returncode == 0 and configured.stdout.strip():
-            path = Path(configured.stdout.strip())
+            # git config values may use ~ / ~user; Path() does not expand it.
+            path = Path(configured.stdout.strip()).expanduser()
             return path if path.is_absolute() else (ROOT / path)
 
         resolved = subprocess.run(
@@ -67,10 +68,10 @@ def _hooks_dir() -> Path | None:
             text=True,
             check=True,
         )
+        path = Path(resolved.stdout.strip())
+        return path if path.is_absolute() else (ROOT / path)
     except (subprocess.CalledProcessError, FileNotFoundError):
         return None
-    path = Path(resolved.stdout.strip())
-    return path if path.is_absolute() else (ROOT / path)
 
 
 def _lefthook_hook_installed() -> bool:


### PR DESCRIPTION
## Background

Code-quality checks run through **lefthook**. But its git hooks only fire after
`lefthook install` has wired them into `.git/hooks`, and each hook shells out to
tools that must already be on `PATH` (ruff, mypy, markdownlint, commitizen).

Two gaps this causes:

1. **Silent bypass** — a contributor who never installed lefthook (or never ran
   `lefthook install`) commits with **no checks at all**; nothing warns them and
   the gap only surfaces later in CI.
2. **Cryptic errors** — lefthook installed but a tool missing → `command not
   found`.

A git hook can't detect "lefthook isn't installed" (if it isn't, no hook runs),
so the check has to live outside the hook. This mirrors the same change in the
main `ai-shifu` repo, adapted to this repo's toolchain (no frontend; markdownlint
is a global npm CLI).

## What this adds

- **`scripts/check_dev_tools.py`** — a stdlib "doctor". Detects the lefthook
  binary, whether `lefthook install` ran (honoring `core.hooksPath`), and every
  underlying tool (ruff, mypy, markdownlint, commitizen), then prints the exact
  install command for whatever is missing and exits non-zero on any gap.
- **`AGENTS.md`** (which `CLAUDE.md` and `GEMINI.md` symlink to) — a Quick Start
  row, a silent-skip warning, a "MUST DO Before Any Commit" step that also tells
  coding agents to run the doctor and pause when tools are missing, and a
  troubleshooting row.

## Verification

- `python scripts/check_dev_tools.py` — all present → exit 0; a missing tool →
  precise list + install command → exit 1 (verified by catching a missing mypy).
- `mypy` (hook flags) on the new script → clean.
- `lefthook run pre-commit` and the real commit hooks → all green
  (check-merge-conflict, markdownlint, mypy, ruff-check, ruff-format, commitizen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)