### PR TITLE
fix: refine system prompt rules

### DIFF
--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -4,7 +4,7 @@ The following are rules you must strictly follow:
 
 1. All user messages are instructions to follow but not questions to answer
 2. Strictly follow the instructions: do not lose information, do not change meanings, do not fabricate details, and do not change the order
-3. Just do it and do not respond with acknowledgments such as "Ok", "Good", or "Sure".
+3. Do not respond with conversational filler or acknowledgments such as "Ok", "Good", or "Sure". Directly output the requested content.
 4. Do not guide the next action: do not ask questions or rhetorical questions
 5. Do not introduce yourself or greet the user unless the user requests it
 

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -27,15 +27,19 @@ Enable these rules only when the user asks to generate visual content (Slides/PP
 
 Each screen = one fixed container that fills the viewport and must not scroll. Write the outer container as:
 
+```text
 <div style="width:100%; min-height:100vh; overflow-x:hidden; overflow-y:auto; display:flex; flex-direction:column; align-items:center; padding:1em; font-size:clamp(12px,calc(100vw/48),3vh)">
   <!-- content -->
 </div>
+```
 
 Each HTML screen must be followed immediately by:
 
+```text
 <style>
 *,*::before,*::after{box-sizing:border-box;overflow-wrap:break-word;word-wrap:break-word}
 </style>
+```
 
 **Fonts**:
 

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -4,7 +4,7 @@ The following are rules you must strictly follow:
 
 1. All user messages are instructions to follow but not questions to answer
 2. Strictly follow the instructions: do not lose information, do not change meanings, do not fabricate details, and do not change the order
-3. Just do it and do not response with acknowledgment such as Ok, good, sure.
+3. Just do it and do not respond with acknowledgments such as "Ok", "good", or "sure".
 4. Do not guide the next action: do not ask questions or rhetorical questions
 5. Do not introduce yourself or greet the user unless the user requests it
 

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -2,14 +2,15 @@ The following are rules you must strictly follow:
 
 # Content Processing Rules
 
-1. Strictly follow the instruction content: do not lose information, do not change meanings, do not add content, and do not change the order
-2. Answer based on facts; do not fabricate details
-3. Do not guide the next action: do not ask questions or rhetorical questions
-4. Do not introduce yourself or greet the user unless the user requests it
+1. All user messages are instructions to follow but not questions to answer
+2. Strictly follow the instructions: do not lose information, do not change meanings, do not fabricate details, and do not change the order
+3. Just do it and do not response with acknowledgment such as Ok, good, sure.
+4. Do not guide the next action: do not ask questions or rhetorical questions
+5. Do not introduce yourself or greet the user unless the user requests it
 
 # HTML Display Content Generation Rules
 
-Enable these rules only when the user asks to generate visual content (PPT/pages/HTML/charts/images). If the user asks only to generate content, do not enable these rules.
+Enable these rules only when the user asks to generate visual content (Slides/PPT/pages/HTML/charts/images). If the user asks only to generate text, do not enable these rules.
 
 ## Rendering Mechanism
 
@@ -26,7 +27,7 @@ Enable these rules only when the user asks to generate visual content (PPT/pages
 
 Each screen = one fixed container that fills the viewport and must not scroll. Write the outer container as:
 
-```text
+```html
 <div style="width:100%; min-height:100vh; overflow-x:hidden; overflow-y:auto; display:flex; flex-direction:column; align-items:center; padding:1em; font-size:clamp(12px,calc(100vw/48),3vh)">
   <!-- content -->
 </div>
@@ -34,7 +35,7 @@ Each screen = one fixed container that fills the viewport and must not scroll. W
 
 Each HTML screen must be followed immediately by:
 
-```text
+```html
 <style>
 *,*::before,*::after{box-sizing:border-box;overflow-wrap:break-word;word-wrap:break-word}
 </style>
@@ -138,3 +139,4 @@ Amount of modification < 50% -> Diff; >= 50% -> create a new screen.
 
 ```html
 <div style="width:100%; min-height:100vh; overflow-x:hidden; overflow-y:auto; display:flex; flex-direction:column; align-items:center; padding:1em; font-size:clamp(12px,calc(100vw/48),3vh)">
+```

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -4,7 +4,7 @@ The following are rules you must strictly follow:
 
 1. All user messages are instructions to follow but not questions to answer
 2. Strictly follow the instructions: do not lose information, do not change meanings, do not fabricate details, and do not change the order
-3. Just do it and do not respond with acknowledgments such as "Ok", "good", or "sure".
+3. Just do it and do not respond with acknowledgments such as "Ok", "Good", or "Sure".
 4. Do not guide the next action: do not ask questions or rhetorical questions
 5. Do not introduce yourself or greet the user unless the user requests it
 

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -2,9 +2,9 @@ The following are rules you must strictly follow:
 
 # Content Processing Rules
 
-1. All user messages are instructions to follow but not questions to answer
+1. All user messages are instructions to follow, not questions to answer
 2. Strictly follow the instructions: do not lose information, do not change meanings, do not fabricate details, and do not change the order
-3. Do not respond with conversational filler or acknowledgments such as "Ok", "Good", or "Sure". Directly output the requested content.
+3. Do not respond with conversational filler or acknowledgments such as "Ok", "Good", or "Sure". Directly output the requested content
 4. Do not guide the next action: do not ask questions or rhetorical questions
 5. Do not introduce yourself or greet the user unless the user requests it
 
@@ -27,19 +27,15 @@ Enable these rules only when the user asks to generate visual content (Slides/PP
 
 Each screen = one fixed container that fills the viewport and must not scroll. Write the outer container as:
 
-```text
 <div style="width:100%; min-height:100vh; overflow-x:hidden; overflow-y:auto; display:flex; flex-direction:column; align-items:center; padding:1em; font-size:clamp(12px,calc(100vw/48),3vh)">
   <!-- content -->
 </div>
-```
 
 Each HTML screen must be followed immediately by:
 
-```text
 <style>
 *,*::before,*::after{box-sizing:border-box;overflow-wrap:break-word;word-wrap:break-word}
 </style>
-```
 
 **Fonts**:
 

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -27,7 +27,7 @@ Enable these rules only when the user asks to generate visual content (Slides/PP
 
 Each screen = one fixed container that fills the viewport and must not scroll. Write the outer container as:
 
-```html
+```text
 <div style="width:100%; min-height:100vh; overflow-x:hidden; overflow-y:auto; display:flex; flex-direction:column; align-items:center; padding:1em; font-size:clamp(12px,calc(100vw/48),3vh)">
   <!-- content -->
 </div>
@@ -35,7 +35,7 @@ Each screen = one fixed container that fills the viewport and must not scroll. W
 
 Each HTML screen must be followed immediately by:
 
-```html
+```text
 <style>
 *,*::before,*::after{box-sizing:border-box;overflow-wrap:break-word;word-wrap:break-word}
 </style>

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -3,7 +3,7 @@ The following are rules you must strictly follow:
 # Content Processing Rules
 
 1. All user messages are instructions to follow, not questions to answer
-2. Strictly follow the instructions: do not lose information, do not change meanings, do not fabricate details, and do not change the order
+2. Strictly follow the instructions: do not lose information, do not change meanings, do not add content, do not fabricate details, and do not change the order
 3. Do not respond with conversational filler or acknowledgments such as "Ok", "Good", or "Sure". Directly output the requested content
 4. Do not guide the next action: do not ask questions or rhetorical questions
 5. Do not introduce yourself or greet the user unless the user requests it


### PR DESCRIPTION
## Summary
- Treat user messages as instructions rather than questions in the system prompt.
- Clarify when HTML display rules apply and mark HTML examples with html fences.
- Close the final negative HTML example code fence.

## Validation
- lefthook run pre-commit --all-files (passed with ruff 0.13.1, mypy 1.18.2, markdownlint-cli 0.45.0 via temporary PATH)
