### PR TITLE
chore: release 0.2.84

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -723,10 +723,10 @@ The text validation toggle affects these three interaction types that include te
 
 #### Toggle State Comparison
 
-| State | Behavior | Performance | Use Cases |
-|-------|----------|-------------|-----------|
-| **Disabled (default)** | Directly accept all text inputs | Fastest, no LLM calls | Dev/testing, trusted input, cost priority |
-| **Enabled** | Use LLM to validate text inputs | Slower, requires LLM | Production, need input validation |
+| State                  | Behavior                         | Performance           | Use Cases                                 |
+| ---------------------- | -------------------------------- | --------------------- | ----------------------------------------- |
+| **Disabled (default)** | Directly accept all text inputs  | Fastest, no LLM calls | Dev/testing, trusted input, cost priority |
+| **Enabled**            | Use LLM to validate text inputs  | Slower, requires LLM  | Production, need input validation         |
 
 #### Usage Examples
 
@@ -1441,10 +1441,10 @@ this single line; `pyproject.toml` reads it via `[tool.setuptools.dynamic]`.
 
 #### Two package types
 
-| Type | Input version | Final version | Install |
-|------|---------------|---------------|---------|
-| `dev` | `0.2.83` (base) | `0.2.83.devN` (auto-incremented) | `pip install --pre markdown-flow==0.2.83.dev1` |
-| `release` | `0.2.83` (base) | `0.2.83` | `pip install markdown-flow==0.2.83` |
+| Type      | Input version   | Final version                        | Install                                            |
+| --------- | --------------- | ------------------------------------ | -------------------------------------------------- |
+| `dev`     | `0.2.83` (base) | `0.2.83.devN` (auto-incremented)     | `pip install --pre markdown-flow==0.2.83.dev1`     |
+| `release` | `0.2.83` (base) | `0.2.83`                             | `pip install markdown-flow==0.2.83`                |
 
 Always enter the **clean base version** (e.g. `0.2.83`); the `.devN` suffix is added
 automatically for dev builds. The Action validates the input: PEP 440 format, must be

--- a/markdown_flow/__init__.py
+++ b/markdown_flow/__init__.py
@@ -88,4 +88,4 @@ __all__ = [
     "replace_variables_in_text",
 ]
 
-__version__ = "0.2.83"
+__version__ = "0.2.84"

--- a/markdown_flow/providers/openai.py
+++ b/markdown_flow/providers/openai.py
@@ -7,7 +7,7 @@ token tracking, and comprehensive metadata.
 
 import time
 from collections.abc import Generator
-from typing import Any
+from typing import Any, cast
 
 from ..llm import LLMProvider
 from .config import ProviderConfig
@@ -82,7 +82,7 @@ class OpenAIProvider(LLMProvider):
             self._print_request_info(messages, actual_model, actual_temperature)
 
         # Format messages
-        formatted_messages = self._format_messages(messages)
+        formatted_messages = cast(Any, self._format_messages(messages))
 
         # Record start time
         start_time = time.time()
@@ -168,18 +168,21 @@ class OpenAIProvider(LLMProvider):
             self._print_request_info(messages, actual_model, actual_temperature)
 
         # Format messages
-        formatted_messages = self._format_messages(messages)
+        formatted_messages = cast(Any, self._format_messages(messages))
 
         # Record start time
         start_time = time.time()
 
         try:
             # Create streaming response
-            stream = self.client.chat.completions.create(
-                model=actual_model,
-                messages=formatted_messages,
-                temperature=actual_temperature,
-                stream=True,
+            stream = cast(
+                Any,
+                self.client.chat.completions.create(
+                    model=actual_model,
+                    messages=formatted_messages,
+                    temperature=actual_temperature,
+                    stream=True,
+                ),
             )
 
             for chunk in stream:

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -45,13 +45,13 @@ Each HTML screen must be followed immediately by:
 
 | Purpose         | style syntax                       |
 | --------------- | ---------------------------------- |
-| Cover title     | font-size:3.5em; font-weight:700  |
-| Page title      | font-size:2.5em; font-weight:700  |
-| Subtitle        | font-size:2em; font-weight:600    |
-| Small heading   | font-size:1.5em; font-weight:600  |
-| Key point title | font-size:1.25em; font-weight:500 |
-| Body text       | font-size:1em                     |
-| Small text      | font-size:0.85em                  |
+| Cover title     | font-size:3.5em; font-weight:700   |
+| Page title      | font-size:2.5em; font-weight:700   |
+| Subtitle        | font-size:2em; font-weight:600     |
+| Small heading   | font-size:1.5em; font-weight:600   |
+| Key point title | font-size:1.25em; font-weight:500  |
+| Body text       | font-size:1em                      |
+| Small text      | font-size:0.85em                   |
 
 ### Decorative Element Rules
 


### PR DESCRIPTION
Publishes markdown-flow 0.2.84 and syncs the release branch back to main.

Verification:
- PyPI version JSON confirms 0.2.84 wheel and sdist
- GitHub Publish workflow succeeded: https://github.com/ai-shifu/markdown-flow-agent-py/actions/runs/28439835990
- lefthook run pre-commit --all-files
- python3 import smoke check
- python -m build and twine check via temporary venv

Notes:
- Also fixes pre-existing markdownlint table alignment and OpenAI SDK mypy typing issues required by the release preflight.