### PR TITLE
fix: avoid concrete HTML example in system prompt

### DIFF
--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -138,5 +138,5 @@ Amount of modification < 50% -> Diff; >= 50% -> create a new screen.
 13. Output HTML as plain text. **Do not** use ```html or any code block marker. Do not output like this:
 
 ```html
-<div style="width:100%; min-height:100vh; overflow-x:hidden; overflow-y:auto; display:flex; flex-direction:column; align-items:center; padding:1em; font-size:clamp(12px,calc(100vw/48),3vh)">
+html code here
 ```


### PR DESCRIPTION
## Summary

- Replace the concrete HTML snippet in `markdown_flow/system_prompt.md` with a neutral placeholder inside the "do not output code blocks" example.
- Keep the prompt focused on the formatting prohibition without giving the model a specific layout snippet to imitate.

## Impact

This reduces prompt ambiguity for generated HTML output while preserving the existing instruction that HTML must be returned as plain text, not fenced code.

## Validation

- `python3 scripts/check_dev_tools.py`
- `python3 -m compileall markdown_flow`
- `pytest` (no tests collected in this checkout)
- `git diff --check`
- `lefthook run pre-commit --all-files`