### PR TITLE
fix(formatter): render HTML wrapped in untagged code fences (0.2.86)

### DIFF
--- a/markdown_flow/__init__.py
+++ b/markdown_flow/__init__.py
@@ -51,7 +51,13 @@ Import Guide:
 # Import core classes and enums
 from .core import MarkdownFlow
 from .enums import BlockType, InputType
-from .formatter import ElementType, FormattedElement, StreamFormatter, format_content
+from .formatter import (
+    ElementType,
+    FormattedElement,
+    StreamFormatter,
+    format_content,
+    strip_untagged_code_fences,
+)
 from .llm import LLMProvider, LLMResult, ProcessMode
 from .parser import (
     InteractionParser,
@@ -81,6 +87,7 @@ __all__ = [
     "FormattedElement",
     "StreamFormatter",
     "format_content",
+    "strip_untagged_code_fences",
     # Main utility functions
     "generate_smart_validation_template",
     "extract_interaction_question",

--- a/markdown_flow/__init__.py
+++ b/markdown_flow/__init__.py
@@ -95,4 +95,4 @@ __all__ = [
     "replace_variables_in_text",
 ]
 
-__version__ = "0.2.85"
+__version__ = "0.2.86"

--- a/markdown_flow/__init__.py
+++ b/markdown_flow/__init__.py
@@ -95,4 +95,4 @@ __all__ = [
     "replace_variables_in_text",
 ]
 
-__version__ = "0.2.84"
+__version__ = "0.2.85"

--- a/markdown_flow/formatter/__init__.py
+++ b/markdown_flow/formatter/__init__.py
@@ -5,6 +5,7 @@ Provides content classification and structured output for SSE streams.
 """
 
 from .format import format_content
+from .sanitize import strip_untagged_code_fences
 from .stream import StreamFormatter
 from .types import ClassifyResult, ElementType, FormattedElement
 
@@ -15,4 +16,5 @@ __all__ = [
     "ClassifyResult",
     "format_content",
     "StreamFormatter",
+    "strip_untagged_code_fences",
 ]

--- a/markdown_flow/formatter/format.py
+++ b/markdown_flow/formatter/format.py
@@ -6,20 +6,31 @@ Mirrors Go formatter/format.go.
 """
 
 from .classifier import Classifier
+from .sanitize import strip_untagged_code_fences
 from .types import ClassifyResult, ElementType, FormattedElement, is_text_family
 
 
-def format_content(content: str) -> list[FormattedElement]:
+def format_content(content: str, *, strip_untagged_fences: bool = True) -> list[FormattedElement]:
     """Format complete content into structured elements.
 
     Args:
         content: The full content string to format.
+        strip_untagged_fences: When True (default), untagged (language-less)
+            code-fence markers are removed before classification, so HTML/SVG
+            an LLM wrapped in a bare ``` renders as its real type instead of a
+            code block. Language-tagged fences (``` ```html ```, ``` ```mermaid ```,
+            ...) are always preserved. Set False to keep raw CommonMark behaviour.
 
     Returns:
         A list of FormattedElement instances.
     """
     if not content:
         return []
+
+    if strip_untagged_fences:
+        content = strip_untagged_code_fences(content)
+        if not content:
+            return []
 
     c = Classifier()
     elements: list[FormattedElement] = []

--- a/markdown_flow/formatter/sanitize.py
+++ b/markdown_flow/formatter/sanitize.py
@@ -1,0 +1,95 @@
+"""
+Content Sanitizer
+
+Utilities for cleaning LLM-generated content before it is classified and
+rendered.
+
+Motivation
+----------
+LLMs intermittently wrap otherwise-renderable output (block-level HTML, SVG
+infographics, plain narrative) in an *untagged* fenced code block, e.g. a bare
+``` line with no info string, sometimes even leaving it unclosed. CommonMark
+faithfully turns that region into a code block, so a renderer shows the raw
+HTML source instead of the intended visual.
+
+This module targets that specific artifact while preserving deliberate code
+blocks. It relies on a simple, explicit convention: **source that is meant to
+be displayed as code carries a language tag** (``` ```html ```, ``` ```python ```,
+``` ```mermaid ```). An *untagged* fence therefore carries no "show the source"
+intent and is treated as noise that can be removed so the wrapped content
+renders normally.
+
+The transformation is opt-in: callers apply it explicitly to generated content.
+It does not change the behaviour of the classifier or ``format_content``.
+"""
+
+from ..parser.code_fence_utils import is_code_fence_end, parse_code_fence_start
+
+
+def _fence_info_string(fence_line: str, fence_char: str) -> str:
+    """Return the info string (language tag) of a fence opening line."""
+    return fence_line.lstrip(" ").lstrip(fence_char).strip()
+
+
+def strip_untagged_code_fences(content: str) -> str:
+    """Remove untagged (language-less) code-fence markers from ``content``.
+
+    An untagged fence is a fence opening line whose info string is empty
+    (a bare ``` or ~~~ with no language). Such markers are dropped so the text
+    they wrapped renders as normal Markdown/HTML instead of code. This handles
+    both paired bare fences and a single unclosed/stray bare fence.
+
+    Language-tagged fences (``` ```html ```, ``` ```mermaid ```, ...) and their
+    contents are left untouched, including their bare closing fence line.
+
+    Args:
+        content: Raw content, typically LLM output.
+
+    Returns:
+        Content with untagged fence markers removed. Everything else, including
+        the lines that were inside an untagged fence, is preserved verbatim.
+
+    Examples:
+        >>> strip_untagged_code_fences("```\\n<div>x</div>\\n```")
+        '<div>x</div>'
+        >>> strip_untagged_code_fences("```html\\n<div>x</div>\\n```")
+        '```html\\n<div>x</div>\\n```'
+    """
+    if not content or ("```" not in content and "~~~" not in content):
+        return content
+
+    lines = content.split("\n")
+    result: list[str] = []
+
+    # When inside a language-tagged fence we copy lines verbatim until the
+    # matching closing fence, so nested bare backticks and the closing fence
+    # itself are preserved.
+    inside_tagged_fence = False
+    open_fence = None
+
+    for line in lines:
+        if inside_tagged_fence:
+            result.append(line)
+            if open_fence is not None and is_code_fence_end(line, open_fence):
+                inside_tagged_fence = False
+                open_fence = None
+            continue
+
+        fence = parse_code_fence_start(line)
+        if fence is None:
+            result.append(line)
+            continue
+
+        info = _fence_info_string(fence.line, fence.char)
+        if info == "":
+            # Untagged fence at the top level: drop the marker line, keep the
+            # content it wrapped. Paired and unclosed bare fences both collapse
+            # here because we never enter a fenced state for them.
+            continue
+
+        # Language-tagged fence: keep it and preserve everything up to its close.
+        result.append(line)
+        inside_tagged_fence = True
+        open_fence = fence
+
+    return "\n".join(result)


### PR DESCRIPTION
## Problem

LLM-generated learner content intermittently wraps otherwise-renderable output — block-level HTML, SVG infographics, even plain narrative — in an **untagged** fenced code block (a bare ``` with no info string), sometimes unclosed. CommonMark faithfully turns that region into a code block, so `format_content` emits a single `code` element and the renderer shows raw HTML source instead of the intended visual.

Confirmed in production learning records: the same infographic is emitted as bare HTML in some regenerations (renders fine) and wrapped in a bare ``` in others (shows source). A single stray/unclosed bare fence can also swallow all trailing narrative as code.

This is distinct from the deliberate "show HTML source" case, which by convention uses a **language-tagged** fence (` ```html `).

## Change

1. **New primitive** `strip_untagged_code_fences(content)` (`markdown_flow/formatter/sanitize.py`): removes untagged ``` / ~~~ fence markers (paired or single/unclosed), keeping the wrapped content; preserves language-tagged fences verbatim.
2. **Wired into `format_content`** via a new `strip_untagged_fences: bool = True` kwarg (default on). This is the method callers use to turn content into typed elements, so bare-fence-wrapped HTML/SVG now classifies as `html` / `svg` with clean, fence-free content instead of a single `code` element. Pass `strip_untagged_fences=False` for raw CommonMark behaviour.

Rationale: source meant to be shown as code carries a language tag, so an untagged fence has no display intent and is treated as an LLM artifact.

Exported from `markdown_flow` and `markdown_flow.formatter`. The classifier and `StreamFormatter` are unchanged.

## Validation

- Local unit tests (paired/unclosed bare fences, tilde, tagged-fence preservation, `format_content` integration + opt-out, idempotency) pass; full formatter suite green. `tests/` is gitignored in this repo, so they are not included here.
- Module doctests pass under `pytest --doctest-modules`.
- Verified on the exact production content: a bare-fence-wrapped infographic (`<div>`/`<svg>` + narrative + `<style>`) comes out of `format_content` as `text` + `html` elements with 0 fences; ` ```html ` stays `code`.
- Pre-commit (mypy, ruff-check, ruff-format, commitizen) clean.

## Release

Published to PyPI as **0.2.86** from this branch (Publish workflow). Consumer bump: ai-shifu/ai-shifu#2076.

## Follow-up (separate)

- A mirrored change in the Go formatter is tracked separately.