### PR TITLE
feat: support no-variable text inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,19 +281,22 @@ class InteractionType(NamedTuple):
 
 ```python
 # TEXT_ONLY: Text input with question
-"?[%{{name}} What is your name?]"
+"?[%{{name}}...What is your name?]"
+
+# TEXT_ONLY without an explicit variable: stored under user_input
+"?[...What is your name?]"
 
 # BUTTONS_ONLY: Button selection only
 "?[%{{level}} Beginner | Intermediate | Expert]"
 
 # BUTTONS_WITH_TEXT: Buttons with fallback text input
-"?[%{{preference}} Option A | Option B | Please specify...]"
+"?[%{{preference}} Option A | Option B | ...Please specify]"
 
 # BUTTONS_MULTI_SELECT: Multi-select buttons
 "?[%{{skills}} Python||JavaScript||Go||Rust]"
 
 # BUTTONS_MULTI_WITH_TEXT: Multi-select with text fallback
-"?[%{{frameworks}} React||Vue||Angular||Please specify others...]"
+"?[%{{frameworks}} React||Vue||Angular||...Please specify others]"
 
 # NON_ASSIGNMENT_BUTTON: Display buttons without variable assignment
 "?[Continue | Cancel | Go Back]"
@@ -391,7 +394,8 @@ result = mf.process(
 # Dictionary format with list values
 user_input = {
     'language': ['Python'],                    # Single selection as list
-    'skills': ['Python', 'JavaScript', 'Go']  # Multi-selection
+    'skills': ['Python', 'JavaScript', 'Go'],  # Multi-selection
+    'user_input': ['Custom answer']            # No-variable text input
 }
 
 # Process interaction

--- a/README_CN.md
+++ b/README_CN.md
@@ -281,19 +281,22 @@ class InteractionType(NamedTuple):
 
 ```python
 # TEXT_ONLY：带问题的文本输入
-"?[%{{name}} 你的名字是什么？]"
+"?[%{{name}}...你的名字是什么？]"
+
+# 无显式变量的 TEXT_ONLY：存储在 user_input 下
+"?[...你的名字是什么？]"
 
 # BUTTONS_ONLY：仅按钮选择
 "?[%{{level}} 初学者 | 中级 | 高级]"
 
 # BUTTONS_WITH_TEXT：按钮与备用文本输入
-"?[%{{preference}} 选项 A | 选项 B | 请指定...]"
+"?[%{{preference}} 选项 A | 选项 B | ...请指定]"
 
 # BUTTONS_MULTI_SELECT：多选按钮
 "?[%{{skills}} Python||JavaScript||Go||Rust]"
 
 # BUTTONS_MULTI_WITH_TEXT：多选带文本备选
-"?[%{{frameworks}} React||Vue||Angular||请指定其他...]"
+"?[%{{frameworks}} React||Vue||Angular||...请指定其他]"
 
 # NON_ASSIGNMENT_BUTTON：显示按钮但不分配变量
 "?[继续 | 取消 | 返回]"
@@ -391,7 +394,8 @@ result = mf.process(
 # 字典格式，值为列表
 user_input = {
     'language': ['Python'],                    # 单选作为列表
-    'skills': ['Python', 'JavaScript', 'Go']  # 多选
+    'skills': ['Python', 'JavaScript', 'Go'],  # 多选
+    'user_input': ['自定义答案']                # 无变量文本输入
 }
 
 # 处理交互

--- a/markdown_flow/__init__.py
+++ b/markdown_flow/__init__.py
@@ -12,7 +12,7 @@ Core Features:
     - Support multiple processing modes: COMPLETE, STREAM
 
 Supported Interaction Types:
-    - TEXT_ONLY: ?[%{{var}}...question] - Text input only
+    - TEXT_ONLY: ?[%{{var}}...question] or ?[...question] - Text input only
     - BUTTONS_ONLY: ?[%{{var}} A|B] - Button selection only
     - BUTTONS_WITH_TEXT: ?[%{{var}} A|B|...question] - Buttons + text input
     - BUTTONS_MULTI_SELECT: ?[%{{var}} A||B||C] - Multi-select buttons

--- a/markdown_flow/core.py
+++ b/markdown_flow/core.py
@@ -394,6 +394,14 @@ class MarkdownFlow:
                 continue
 
             variable_name = parse_result.get("variable")
+            interaction_type = parse_result.get("type")
+
+            if not variable_name and interaction_type in [
+                InteractionType.TEXT_ONLY,
+                InteractionType.BUTTONS_WITH_TEXT,
+                InteractionType.BUTTONS_MULTI_WITH_TEXT,
+            ]:
+                variable_name = "user_input"
 
             # No variable interaction (e.g. ?[Continue])
             if not variable_name:
@@ -828,6 +836,12 @@ class MarkdownFlow:
             return self._render_error(error_msg, mode, context, variables)
 
         interaction_type = parse_result.get("type")
+        if parse_result.get("uses_default_input") and not target_values:
+            for values in user_input.values():
+                if values:
+                    target_values = values
+                    user_input = {target_variable: values}
+                    break
 
         # Process user input based on interaction type
         if interaction_type in [

--- a/markdown_flow/formatter/sanitize.py
+++ b/markdown_flow/formatter/sanitize.py
@@ -23,7 +23,7 @@ The transformation is opt-in: callers apply it explicitly to generated content.
 It does not change the behaviour of the classifier or ``format_content``.
 """
 
-from ..parser.code_fence_utils import is_code_fence_end, parse_code_fence_start
+from ..parser.code_fence_utils import CodeFenceInfo, is_code_fence_end, parse_code_fence_start
 
 
 def _fence_info_string(fence_line: str, fence_char: str) -> str:
@@ -65,7 +65,7 @@ def strip_untagged_code_fences(content: str) -> str:
     # matching closing fence, so nested bare backticks and the closing fence
     # itself are preserved.
     inside_tagged_fence = False
-    open_fence = None
+    open_fence: CodeFenceInfo | None = None
 
     for line in lines:
         if inside_tagged_fence:

--- a/markdown_flow/parser/interaction.py
+++ b/markdown_flow/parser/interaction.py
@@ -93,7 +93,7 @@ class InteractionParser:
             if has_variable:
                 assert variable_name is not None, "variable_name should not be None when has_variable is True"
                 return self._layer3_parse_variable_interaction(variable_name, remaining_content)
-            return self._layer3_parse_display_buttons(inner_content)
+            return self._layer3_parse_no_variable_interaction(inner_content)
 
         except Exception as e:
             return self._create_error_result(f"Parsing error: {str(e)}")
@@ -357,3 +357,36 @@ class InteractionParser:
             Error result dictionary
         """
         return {"type": None, "error": error_message}  # type: ignore[unreachable]
+
+    def _layer3_parse_no_variable_interaction(self, content: str) -> dict[str, Any]:
+        """
+        Layer 3: Parse no-variable interactions.
+
+        Args:
+            content: Content to parse
+
+        Returns:
+            Parsing result dictionary
+        """
+        if "..." not in content:
+            return self._layer3_parse_display_buttons(content)
+
+        before_ellipsis, question = (part.strip() for part in content.split("...", 1))
+
+        if before_ellipsis:
+            buttons, is_multi_select = self._parse_buttons(before_ellipsis)
+            interaction_type = InteractionType.BUTTONS_MULTI_WITH_TEXT if is_multi_select else InteractionType.BUTTONS_WITH_TEXT
+            return {
+                "type": interaction_type,
+                "buttons": buttons,
+                "question": question,
+                "is_multi_select": is_multi_select,
+                "uses_default_input": True,
+            }
+
+        return {
+            "type": InteractionType.TEXT_ONLY,
+            "question": question,
+            "is_multi_select": False,
+            "uses_default_input": True,
+        }

--- a/markdown_flow/utils.py
+++ b/markdown_flow/utils.py
@@ -32,6 +32,7 @@ from .constants import (
     VALIDATION_TASK_TEMPLATE,
     VARIABLE_DEFAULT_VALUE,
 )
+from .parser.interaction import InteractionParser as CanonicalInteractionParser
 
 
 def extract_variables_from_text(text: str) -> list[str]:
@@ -196,7 +197,7 @@ class InteractionParser:
             if has_variable:
                 assert variable_name is not None, "variable_name should not be None when has_variable is True"
                 return self._layer3_parse_variable_interaction(variable_name, remaining_content)
-            return self._layer3_parse_display_buttons(inner_content)
+            return CanonicalInteractionParser().parse(content)
 
         except Exception as e:
             return self._create_error_result(f"Parsing error: {str(e)}")


### PR DESCRIPTION
## Summary
- Treat no-variable `?[...question]` interactions as text input instead of display-only buttons.
- Normalize submitted values for no-variable text inputs under `user_input`, while preserving `?[Continue]` and other display-only button behavior.
- Document the no-variable text input form in English and Chinese README examples.
- Add a small sanitizer type annotation fix so full mypy checks pass on the current base.

## Validation
- `python3 scripts/check_dev_tools.py`
- targeted parser/process compatibility script
- `ruff format markdown_flow/formatter/sanitize.py markdown_flow/parser/interaction.py markdown_flow/utils.py markdown_flow/core.py markdown_flow/__init__.py`
- `mypy --ignore-missing-imports --follow-imports=silent --no-strict-optional --allow-untyped-defs --allow-incomplete-defs --no-warn-no-return --show-error-codes markdown_flow/formatter/sanitize.py markdown_flow/parser/interaction.py markdown_flow/utils.py markdown_flow/core.py markdown_flow/__init__.py`
- `ruff check markdown_flow/formatter/sanitize.py markdown_flow/parser/interaction.py markdown_flow/utils.py markdown_flow/core.py markdown_flow/__init__.py`
- `lefthook run pre-commit --all-files`

Note: in this sandbox, lefthook's final automatic `git add --force` step reports it cannot create `.git/index.lock`, but all hook checks passed successfully.