### PR TITLE
fix: stop models from echoing the next-interaction note into lesson content

### DIFF
--- a/markdown_flow/__init__.py
+++ b/markdown_flow/__init__.py
@@ -106,4 +106,4 @@ __all__ = [
     "replace_variables_in_text",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/markdown_flow/constants.py
+++ b/markdown_flow/constants.py
@@ -250,9 +250,16 @@ CONTEXT_BUTTON_OPTIONS_TEMPLATE = (
 )
 
 # Next interaction context prompt templates
+# The Markdown heading marker delimits the note the same way the other
+# context sections do (see CONTEXT_QUESTION_MARKER above); the system prompt
+# references this heading by name to forbid echoing the note into the output
+# (models occasionally reproduced the undelimited note verbatim as content).
+NEXT_INTERACTION_CONTEXT_MARKER = "# Next Interaction Note"
 NEXT_INTERACTION_CONTEXT_INTRO = (
+    f"{NEXT_INTERACTION_CONTEXT_MARKER}\n"
     "The next interaction will appear immediately after this content. When generating the current content, connect to it naturally. "
-    "You may briefly restate, explain, or set up the available choices so the user understands what they will decide next, but do not output the interaction syntax or answer on the user's behalf."
+    "You may briefly restate, explain, or set up the available choices so the user understands what they will decide next, but do not output the interaction syntax or answer on the user's behalf. "
+    "This note is internal guidance and is never shown to the user: never quote, translate, or reproduce any part of this section in your output."
 )
 NEXT_INTERACTION_TEXT_INPUT_TEMPLATE = "The next interaction asks the user to answer in text: {question}"
 NEXT_INTERACTION_SINGLE_CHOICE_TEMPLATE = "The next interaction is a single-choice question. The user will choose one option from: {options}"

--- a/markdown_flow/system_prompt.md
+++ b/markdown_flow/system_prompt.md
@@ -7,6 +7,7 @@ The following are rules you must strictly follow:
 3. Do not respond with conversational filler or acknowledgments such as "Ok", "Good", or "Sure". Directly output the requested content
 4. Do not guide the next action: do not ask questions or rhetorical questions
 5. Do not introduce yourself or greet the user unless the user requests it
+6. A user message may end with a `# Next Interaction Note` section. It is internal guidance about the interaction that follows the content: use it to shape a natural ending, but never quote, translate, or reproduce any text from that section in your output. This applies to every occurrence, including ones inside earlier conversation turns
 
 # HTML Display Content Generation Rules
 


### PR DESCRIPTION
## Problem

When a content block is followed by an interaction block, the library appends a plain-text guidance note ("The next interaction will appear immediately after this content...") to the user message. In production (ai-shifu), models occasionally reproduced this note verbatim inside the generated lesson content — observed at a ~0.2-0.7% rate per content block since the feature shipped (5 occurrences between 2026-07-29 and 2026-08-04), surfacing raw English instruction text to learners.

The note had no delimiter and no self-referential prohibition, so nothing distinguished it from content the model should render.

## Fix (no XML — house-style Markdown markers)

Consistent with the existing context section markers (`# User Question`, `# Conversation Context`, `## Predefined Options`):

- `NEXT_INTERACTION_CONTEXT_MARKER = "# Next Interaction Note"` now opens the note, giving it a named, stable boundary.
- The intro gains an explicit sentence: the note is internal guidance, never shown to the user, and must never be quoted, translated, or reproduced.
- The base system prompt (`system_prompt.md`, Content Processing Rules) gains rule 6 referencing the section by its heading name and forbidding echoing it — including occurrences inside earlier conversation turns (callers that replay history verbatim keep per-turn copies of the note).
- Version bumped to 0.3.1.

## Tests

Local (gitignored) suite extended: the note starts with the heading marker, contains the no-echo sentence, and the system prompt references the section name. 145 local tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of follow-up interaction notes to help guide response endings appropriately.
  - Ensured these notes remain internal and are not quoted, translated, or reproduced in generated responses.

- **Documentation**
  - Added guidance clarifying how follow-up interaction notes should be interpreted and handled.

- **Chores**
  - Updated the package version to 0.3.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->